### PR TITLE
Feature/add elastic load balancer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module github.com/nifcloud/nifcloud-cloud-controller-manager
 go 1.20
 
 require (
-	github.com/aws/smithy-go v1.14.0
-	github.com/nifcloud/nifcloud-sdk-go v1.21.0
+	github.com/aws/smithy-go v1.14.2
+	github.com/nifcloud/nifcloud-sdk-go v1.22.1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/samber/lo v1.38.1
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	k8s.io/api v0.28.3
 	k8s.io/apimachinery v0.28.3
 	k8s.io/cloud-provider v0.28.3
@@ -80,7 +81,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.19.0 // indirect
 	golang.org/x/crypto v0.15.0 // indirect
-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/net v0.18.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/aws/aws-sdk-go-v2 v1.17.4 h1:wyC6p9Yfq6V2y98wfDsj6OnNQa4w2BLGCLIxzNhwOGY=
 github.com/aws/aws-sdk-go-v2 v1.17.4/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
-github.com/aws/smithy-go v1.14.0 h1:+X90sB94fizKjDmwb4vyl2cTTPXTE5E2G/1mjByb0io=
-github.com/aws/smithy-go v1.14.0/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/aws/smithy-go v1.14.2 h1:MJU9hqBGbvWZdApzpvoF2WAIJDbtjK2NDJSiJP7HblQ=
+github.com/aws/smithy-go v1.14.2/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -127,8 +127,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nifcloud/nifcloud-sdk-go v1.21.0 h1:ZdsSI42mV3joah8aL2r34PaO9xZFOIG3ifZ2U6MYZ8A=
-github.com/nifcloud/nifcloud-sdk-go v1.21.0/go.mod h1:OlT+2biDJKG7FfXJNpTK+KZaBTEpoRYIyRC/meumbzg=
+github.com/nifcloud/nifcloud-sdk-go v1.22.1 h1:r70lwa0Blqx8fPSoSRE/F8OHdEvgCXHvm2u3doEzy3Q=
+github.com/nifcloud/nifcloud-sdk-go v1.22.1/go.mod h1:+vk7SQl3ed2U4OqEQWmUqW3C/KqtB8VNmbElIbhu2LU=
 github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_client.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_client.go
@@ -77,7 +77,7 @@ type ElasticLoadBalancer struct {
 	HealthCheckTarget             string
 	HealthCheckInterval           int32
 	HealthCheckUnhealthyThreshold int32
-	NetworkInterface              []NetworkInterface
+	NetworkInterfaces            []NetworkInterface
 }
 
 // NetworkInterface is network interface detail
@@ -604,7 +604,7 @@ func (c *nifcloudAPIClient) DescribeElasticLoadBalancers(ctx context.Context, na
 					SystemIpAddresses: systemIPAddresses,
 					IsVipNetwork:      nifcloud.ToBool(networkInterfaceDesc.IsVipNetwork),
 				}
-				elb.NetworkInterface = append(elb.NetworkInterface, networkInterface)
+				elb.NetworkInterfaces = append(elb.NetworkInterfaces, networkInterface)
 			}
 
 			result = append(result, elb)
@@ -671,7 +671,7 @@ func (c *nifcloudAPIClient) createElasticLoadBalancer(ctx context.Context, elast
 	}
 
 	input.NetworkInterface = []types.RequestNetworkInterfaceOfNiftyCreateElasticLoadBalancer{}
-	for _, networkInterface := range elasticLoadBalancer.NetworkInterface {
+	for _, networkInterface := range elasticLoadBalancer.NetworkInterfaces {
 		systemIPAdresses := []types.RequestSystemIpAddresses{}
 		for _, systemIPAdress := range networkInterface.SystemIpAddresses {
 			systemIPAdresses = append(systemIPAdresses, types.RequestSystemIpAddresses{

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_client.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_client.go
@@ -5,6 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
+	"time"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/aws/smithy-go"
 	"github.com/nifcloud/nifcloud-sdk-go/nifcloud"
@@ -19,6 +23,9 @@ const (
 	loadBalancerFilterType = "1"
 
 	filterAnyIPAddresses = "*.*.*.*"
+
+	securityGroupAppliedWaiterTimeout       = 3 * time.Minute
+	elasticLoadBalancerAppliedWaiterTimeout = 10 * time.Minute
 )
 
 // Instance is instance detail
@@ -55,6 +62,48 @@ type Filter struct {
 	IPAddress   string
 }
 
+// ElasticLoadBalancer is elastic load balancer detail
+type ElasticLoadBalancer struct {
+	AvailabilityZone              string
+	Name                          string
+	VIP                           string
+	AccountingType                string
+	Protocol                      string
+	NetworkVolume                 int32
+	BalancingType                 int32
+	BalancingTargets              []Instance
+	LoadBalancerPort              int32
+	InstancePort                  int32
+	HealthCheckTarget             string
+	HealthCheckInterval           int32
+	HealthCheckUnhealthyThreshold int32
+	NetworkInterface              []NetworkInterface
+}
+
+// NetworkInterface is network interface detail
+type NetworkInterface struct {
+	NetworkId         string
+	NetworkName       string
+	IPAddress         string
+	SystemIpAddresses []string
+	IsVipNetwork      bool
+}
+
+// SecurityGroup is security group detail
+type SecurityGroup struct {
+	GroupName string
+	Rules     []SecurityGroupRule
+}
+
+// SecurityGroupRule is security group rule detail
+type SecurityGroupRule struct {
+	IpProtocol string
+	FromPort   int32
+	ToPort     int32
+	InOut      string
+	IpRanges   []string
+}
+
 // Equals method checks whether specified instance is the same
 func (i *Instance) Equals(other Instance) bool {
 	if i.InstanceUniqueID != "" && other.InstanceUniqueID != "" {
@@ -74,6 +123,20 @@ func (lb *LoadBalancer) String() string {
 	return fmt.Sprintf("%s (%d -> %d)", lb.Name, lb.LoadBalancerPort, lb.InstancePort)
 }
 
+func (lb *ElasticLoadBalancer) Equals(other ElasticLoadBalancer) bool {
+	return lb.Name == other.Name &&
+		lb.LoadBalancerPort == other.LoadBalancerPort &&
+		lb.InstancePort == other.InstancePort
+}
+
+func (lb *ElasticLoadBalancer) String() string {
+	return fmt.Sprintf("%s (%d -> %d)", lb.Name, lb.LoadBalancerPort, lb.InstancePort)
+}
+
+func (r *SecurityGroupRule) String() string {
+	return fmt.Sprintf("%s %s [%d-%d] : %s", r.InOut, r.IpProtocol, r.FromPort, r.ToPort, r.IpRanges)
+}
+
 // CloudAPIClient is interface
 type CloudAPIClient interface {
 	// Instance
@@ -88,6 +151,21 @@ type CloudAPIClient interface {
 	RegisterInstancesWithLoadBalancer(ctx context.Context, loadBalancer *LoadBalancer, instances []Instance) error
 	DeregisterInstancesFromLoadBalancer(ctx context.Context, loadBalancer *LoadBalancer, instances []Instance) error
 	SetFilterForLoadBalancer(ctx context.Context, loadBalancer *LoadBalancer, filters []Filter) error
+
+	// ElasticLoadBalancer
+	DescribeElasticLoadBalancers(ctx context.Context, name string) ([]ElasticLoadBalancer, error)
+	CreateElasticLoadBalancer(ctx context.Context, loadBalancer *ElasticLoadBalancer) (string, error)
+	RegisterPortWithElasticLoadBalancer(ctx context.Context, loadBalancer *ElasticLoadBalancer) error
+	ConfigureElasticLoadBalancerHealthCheck(ctx context.Context, elasticLoadBalancer *ElasticLoadBalancer) error
+	DeleteElasticLoadBalancer(ctx context.Context, loadBalancer *ElasticLoadBalancer) error
+	RegisterInstancesWithElasticLoadBalancer(ctx context.Context, loadBalancer *ElasticLoadBalancer, instances []Instance) error
+	DeregisterInstancesFromElasticLoadBalancer(ctx context.Context, loadBalancer *ElasticLoadBalancer, instances []Instance) error
+
+	// SecurityGroup
+	DescribeSecurityGroupsByInstanceIDs(ctx context.Context, instanceIDs []string) ([]SecurityGroup, error)
+	AuthorizeSecurityGroupIngress(ctx context.Context, securityGroupName string, securityGroupRule *SecurityGroupRule) error
+	RevokeSecurityGroupIngress(ctx context.Context, securityGroupName string, securityGroupRule *SecurityGroupRule) error
+	WaitSecurityGroupApplied(ctx context.Context, securityGroupName string) error
 }
 
 type nifcloudAPIClient struct {
@@ -467,5 +545,475 @@ func (c *nifcloudAPIClient) DeleteLoadBalancer(ctx context.Context, loadBalancer
 		return fmt.Errorf("failed to delete load balancer %s: %w", loadBalancer.String(), err)
 	}
 
+	return nil
+}
+
+func (c *nifcloudAPIClient) DescribeElasticLoadBalancers(ctx context.Context, name string) ([]ElasticLoadBalancer, error) {
+	input := &computing.NiftyDescribeElasticLoadBalancersInput{
+		ElasticLoadBalancers: &types.RequestElasticLoadBalancers{
+			ListOfRequestElasticLoadBalancerName: []string{name},
+		},
+	}
+	res, err := c.client.NiftyDescribeElasticLoadBalancers(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch load balancers info for %q: %v", name, err)
+	}
+
+	result := []ElasticLoadBalancer{}
+	for _, elbDesc := range res.NiftyDescribeElasticLoadBalancersResult.ElasticLoadBalancerDescriptions {
+		for _, listener := range elbDesc.ElasticLoadBalancerListenerDescriptions {
+			elb := ElasticLoadBalancer{
+				Name:                          nifcloud.ToString(elbDesc.ElasticLoadBalancerName),
+				VIP:                           nifcloud.ToString(elbDesc.DNSName),
+				AccountingType:                nifcloud.ToString(elbDesc.AccountingType),
+				Protocol:                      nifcloud.ToString(listener.Listener.Protocol),
+				BalancingType:                 nifcloud.ToInt32(listener.Listener.BalancingType),
+				LoadBalancerPort:              nifcloud.ToInt32(listener.Listener.ElasticLoadBalancerPort),
+				InstancePort:                  nifcloud.ToInt32(listener.Listener.InstancePort),
+				HealthCheckTarget:             nifcloud.ToString(listener.Listener.HealthCheck.Target),
+				HealthCheckInterval:           nifcloud.ToInt32(listener.Listener.HealthCheck.Interval),
+				HealthCheckUnhealthyThreshold: nifcloud.ToInt32(listener.Listener.HealthCheck.UnhealthyThreshold),
+			}
+
+			networkVolume, err := strconv.Atoi(*elbDesc.NetworkVolume)
+			if err != nil {
+				return nil, err
+			}
+			elb.NetworkVolume = int32(networkVolume)
+
+			balancingTargets := []Instance{}
+			for _, instance := range elbDesc.ElasticLoadBalancerListenerDescriptions[0].Listener.Instances {
+				balancingTargets = append(balancingTargets,
+					Instance{
+						InstanceID:       nifcloud.ToString(instance.InstanceId),
+						InstanceUniqueID: nifcloud.ToString(instance.InstanceUniqueId),
+					},
+				)
+			}
+			elb.BalancingTargets = balancingTargets
+
+			for _, networkInterfaceDesc := range elbDesc.NetworkInterfaces {
+				systemIPAddresses := []string{}
+				for _, systemIPAddress := range networkInterfaceDesc.SystemIpAddresses {
+					systemIPAddresses = append(systemIPAddresses, nifcloud.ToString(systemIPAddress.SystemIpAddress))
+				}
+				networkInterface := NetworkInterface{
+					NetworkId:         nifcloud.ToString(networkInterfaceDesc.NetworkId),
+					NetworkName:       nifcloud.ToString(networkInterfaceDesc.NetworkName),
+					IPAddress:         nifcloud.ToString(networkInterfaceDesc.IpAddress),
+					SystemIpAddresses: systemIPAddresses,
+					IsVipNetwork:      nifcloud.ToBool(networkInterfaceDesc.IsVipNetwork),
+				}
+				elb.NetworkInterface = append(elb.NetworkInterface, networkInterface)
+			}
+
+			result = append(result, elb)
+		}
+	}
+
+	return result, nil
+}
+
+func (c *nifcloudAPIClient) CreateElasticLoadBalancer(ctx context.Context, elasticLoadBalancer *ElasticLoadBalancer) (string, error) {
+	if elasticLoadBalancer == nil {
+		return "", fmt.Errorf("loadBalancer is nil")
+	}
+
+	vip, err := c.createElasticLoadBalancer(ctx, elasticLoadBalancer)
+	if err != nil {
+		return "", fmt.Errorf("failed to create load balancer %s: %w", elasticLoadBalancer, err)
+	}
+	if err := c.WaitElasticLoadBalancerApplied(ctx, elasticLoadBalancer.Name); err != nil {
+		return "", err
+	}
+
+	if err := c.ConfigureElasticLoadBalancerHealthCheck(ctx, elasticLoadBalancer); err != nil {
+		return "", fmt.Errorf("failed to configure health check of load balancer %s: %w", elasticLoadBalancer, err)
+	}
+	if err := c.WaitElasticLoadBalancerApplied(ctx, elasticLoadBalancer.Name); err != nil {
+		return "", err
+	}
+
+	if err := c.RegisterInstancesWithElasticLoadBalancer(ctx, elasticLoadBalancer, nil); err != nil {
+		return "", fmt.Errorf("failed to register instances with load balancer %s: %w", elasticLoadBalancer, err)
+	}
+	if err := c.WaitElasticLoadBalancerApplied(ctx, elasticLoadBalancer.Name); err != nil {
+		return "", err
+	}
+
+	return vip, nil
+}
+
+func (c *nifcloudAPIClient) createElasticLoadBalancer(ctx context.Context, elasticLoadBalancer *ElasticLoadBalancer) (string, error) {
+	input := &computing.NiftyCreateElasticLoadBalancerInput{
+		AvailabilityZones: &types.ListOfRequestAvailabilityZones{
+			Member: []string{elasticLoadBalancer.AvailabilityZone},
+		},
+		ElasticLoadBalancerName: nifcloud.String(elasticLoadBalancer.Name),
+		Listeners: &types.ListOfRequestListenersOfNiftyCreateElasticLoadBalancer{
+			Member: []types.RequestListenersOfNiftyCreateElasticLoadBalancer{
+				{
+					ElasticLoadBalancerPort: nifcloud.Int32(elasticLoadBalancer.LoadBalancerPort),
+					Protocol:                types.ProtocolOfListenersForNiftyCreateElasticLoadBalancer(elasticLoadBalancer.Protocol),
+					InstancePort:            nifcloud.Int32(elasticLoadBalancer.InstancePort),
+				},
+			},
+		},
+	}
+	if elasticLoadBalancer.BalancingType != 0 {
+		input.Listeners.Member[0].BalancingType = nifcloud.Int32(elasticLoadBalancer.BalancingType)
+	}
+	if elasticLoadBalancer.AccountingType != "" {
+		input.AccountingType = types.AccountingTypeOfNiftyCreateElasticLoadBalancerRequest(elasticLoadBalancer.AccountingType)
+	}
+	if elasticLoadBalancer.NetworkVolume != 0 {
+		input.NetworkVolume = nifcloud.Int32(elasticLoadBalancer.NetworkVolume)
+	}
+
+	input.NetworkInterface = []types.RequestNetworkInterfaceOfNiftyCreateElasticLoadBalancer{}
+	for _, networkInterface := range elasticLoadBalancer.NetworkInterface {
+		systemIPAdresses := []types.RequestSystemIpAddresses{}
+		for _, systemIPAdress := range networkInterface.SystemIpAddresses {
+			systemIPAdresses = append(systemIPAdresses, types.RequestSystemIpAddresses{
+				SystemIpAddress: nifcloud.String(systemIPAdress),
+			})
+		}
+		input.NetworkInterface = append(input.NetworkInterface, types.RequestNetworkInterfaceOfNiftyCreateElasticLoadBalancer{
+			NetworkId:                      nifcloud.String(networkInterface.NetworkId),
+			IpAddress:                      nifcloud.String(networkInterface.IPAddress),
+			ListOfRequestSystemIpAddresses: systemIPAdresses,
+			IsVipNetwork:                   nifcloud.Bool(networkInterface.IsVipNetwork),
+		})
+	}
+
+	res, err := c.client.NiftyCreateElasticLoadBalancer(ctx, input)
+	if err != nil {
+		return "", fmt.Errorf("could not create new load balancer %s: %w", elasticLoadBalancer, err)
+	}
+
+	return nifcloud.ToString(res.NiftyCreateElasticLoadBalancerResult.DNSName), nil
+}
+
+func (c *nifcloudAPIClient) RegisterPortWithElasticLoadBalancer(ctx context.Context, elasticLoadBalancer *ElasticLoadBalancer) error {
+	if elasticLoadBalancer == nil {
+		return fmt.Errorf("loadBalancer is nil")
+	}
+
+	if err := c.registerPortWithElasticLoadBalancer(ctx, elasticLoadBalancer); err != nil {
+		return fmt.Errorf("failed to register port with load balancer %s: %w", elasticLoadBalancer.String(), err)
+	}
+	if err := c.WaitElasticLoadBalancerApplied(ctx, elasticLoadBalancer.Name); err != nil {
+		return err
+	}
+
+	if err := c.ConfigureElasticLoadBalancerHealthCheck(ctx, elasticLoadBalancer); err != nil {
+		return fmt.Errorf("failed to configure health check of load balancer %s: %w", elasticLoadBalancer.String(), err)
+	}
+	if err := c.WaitElasticLoadBalancerApplied(ctx, elasticLoadBalancer.Name); err != nil {
+		return err
+	}
+
+	if err := c.RegisterInstancesWithElasticLoadBalancer(ctx, elasticLoadBalancer, nil); err != nil {
+		return fmt.Errorf("failed to register instances with load balancer %s: %w", elasticLoadBalancer, err)
+	}
+	if err := c.WaitElasticLoadBalancerApplied(ctx, elasticLoadBalancer.Name); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *nifcloudAPIClient) registerPortWithElasticLoadBalancer(ctx context.Context, elasticLoadBalancer *ElasticLoadBalancer) error {
+	input := &computing.NiftyRegisterPortWithElasticLoadBalancerInput{
+		ElasticLoadBalancerName: nifcloud.String(elasticLoadBalancer.Name),
+		Listeners: &types.ListOfRequestListenersOfNiftyRegisterPortWithElasticLoadBalancer{
+			Member: []types.RequestListenersOfNiftyRegisterPortWithElasticLoadBalancer{
+				{
+					ElasticLoadBalancerPort: nifcloud.Int32(elasticLoadBalancer.LoadBalancerPort),
+					InstancePort:            nifcloud.Int32(elasticLoadBalancer.InstancePort),
+					Protocol:                types.ProtocolOfListenersForNiftyRegisterPortWithElasticLoadBalancer(elasticLoadBalancer.Protocol),
+				},
+			},
+		},
+	}
+	if elasticLoadBalancer.BalancingType != 0 {
+		input.Listeners.Member[0].BalancingType = nifcloud.Int32(elasticLoadBalancer.BalancingType)
+	}
+
+	if _, err := c.client.NiftyRegisterPortWithElasticLoadBalancer(ctx, input); err != nil {
+		return fmt.Errorf("could not register port with load balancer %s: %w", elasticLoadBalancer.String(), err)
+	}
+
+	return nil
+}
+
+func (c *nifcloudAPIClient) ConfigureElasticLoadBalancerHealthCheck(ctx context.Context, elasticLoadBalancer *ElasticLoadBalancer) error {
+	if elasticLoadBalancer == nil {
+		return fmt.Errorf("loadBalancer is nil")
+	}
+
+	input := &computing.NiftyConfigureElasticLoadBalancerHealthCheckInput{
+		ElasticLoadBalancerName: nifcloud.String(elasticLoadBalancer.Name),
+		ElasticLoadBalancerPort: nifcloud.Int32(elasticLoadBalancer.LoadBalancerPort),
+		InstancePort:            nifcloud.Int32(elasticLoadBalancer.InstancePort),
+		HealthCheck: &types.RequestHealthCheckOfNiftyConfigureElasticLoadBalancerHealthCheck{
+			Interval:           nifcloud.Int32(elasticLoadBalancer.HealthCheckInterval),
+			Target:             nifcloud.String(elasticLoadBalancer.HealthCheckTarget),
+			UnhealthyThreshold: nifcloud.Int32(elasticLoadBalancer.HealthCheckUnhealthyThreshold),
+		},
+		Protocol: types.ProtocolOfNiftyConfigureElasticLoadBalancerHealthCheckRequest(elasticLoadBalancer.Protocol),
+	}
+	if _, err := c.client.NiftyConfigureElasticLoadBalancerHealthCheck(ctx, input); err != nil {
+		return fmt.Errorf("failed to configure health check for load balancer %s: %w", elasticLoadBalancer, err)
+	}
+
+	return nil
+}
+
+func (c *nifcloudAPIClient) DeleteElasticLoadBalancer(ctx context.Context, elasticLoadBalancer *ElasticLoadBalancer) error {
+	if elasticLoadBalancer == nil {
+		return fmt.Errorf("loadBalancer is nil")
+	}
+
+	input := &computing.NiftyDeleteElasticLoadBalancerInput{
+		ElasticLoadBalancerName: nifcloud.String(elasticLoadBalancer.Name),
+		ElasticLoadBalancerPort: nifcloud.Int32(elasticLoadBalancer.LoadBalancerPort),
+		InstancePort:            nifcloud.Int32(elasticLoadBalancer.InstancePort),
+		Protocol:                types.ProtocolOfNiftyDeleteElasticLoadBalancerRequest(elasticLoadBalancer.Protocol),
+	}
+	if _, err := c.client.NiftyDeleteElasticLoadBalancer(ctx, input); err != nil {
+		return fmt.Errorf("failed to delete load balancer %s: %w", elasticLoadBalancer.String(), err)
+	}
+
+	return nil
+}
+
+func (c *nifcloudAPIClient) RegisterInstancesWithElasticLoadBalancer(ctx context.Context, elasticLoadBalancer *ElasticLoadBalancer, instances []Instance) error {
+	if elasticLoadBalancer == nil {
+		return fmt.Errorf("loadBalancer is nil")
+	}
+
+	if instances == nil {
+		instances = elasticLoadBalancer.BalancingTargets
+	}
+
+	registerInstances := []types.RequestInstancesOfNiftyRegisterInstancesWithElasticLoadBalancer{}
+	for _, instance := range instances {
+		registerInstances = append(registerInstances,
+			types.RequestInstancesOfNiftyRegisterInstancesWithElasticLoadBalancer{
+				InstanceId: nifcloud.String(instance.InstanceID),
+			})
+	}
+
+	input := &computing.NiftyRegisterInstancesWithElasticLoadBalancerInput{
+		ElasticLoadBalancerName: nifcloud.String(elasticLoadBalancer.Name),
+		ElasticLoadBalancerPort: nifcloud.Int32(elasticLoadBalancer.LoadBalancerPort),
+		InstancePort:            nifcloud.Int32(elasticLoadBalancer.InstancePort),
+		Protocol:                types.ProtocolOfNiftyRegisterInstancesWithElasticLoadBalancerRequest(elasticLoadBalancer.Protocol),
+		Instances: &types.ListOfRequestInstancesOfNiftyRegisterInstancesWithElasticLoadBalancer{
+			Member: registerInstances,
+		},
+	}
+	if _, err := c.client.NiftyRegisterInstancesWithElasticLoadBalancer(ctx, input); err != nil {
+		return fmt.Errorf("failed to register instances to load balancer %s: %w", elasticLoadBalancer, err)
+	}
+
+	return nil
+}
+
+func (c *nifcloudAPIClient) DeregisterInstancesFromElasticLoadBalancer(ctx context.Context, elasticLoadBalancer *ElasticLoadBalancer, instances []Instance) error {
+	if elasticLoadBalancer == nil {
+		return fmt.Errorf("loadBalancer is nil")
+	}
+
+	deregisterInstances := []types.RequestInstancesOfNiftyDeregisterInstancesFromElasticLoadBalancer{}
+	for _, instance := range instances {
+		deregisterInstances = append(deregisterInstances,
+			types.RequestInstancesOfNiftyDeregisterInstancesFromElasticLoadBalancer{
+				InstanceId: nifcloud.String(instance.InstanceID),
+			})
+	}
+
+	input := &computing.NiftyDeregisterInstancesFromElasticLoadBalancerInput{
+		ElasticLoadBalancerName: nifcloud.String(elasticLoadBalancer.Name),
+		ElasticLoadBalancerPort: nifcloud.Int32(elasticLoadBalancer.LoadBalancerPort),
+		InstancePort:            nifcloud.Int32(elasticLoadBalancer.InstancePort),
+		Instances: &types.ListOfRequestInstancesOfNiftyDeregisterInstancesFromElasticLoadBalancer{
+			Member: deregisterInstances,
+		},
+	}
+	if _, err := c.client.NiftyDeregisterInstancesFromElasticLoadBalancer(ctx, input); err != nil {
+		return fmt.Errorf("failed to deregister instances from load balancer %s: %w", elasticLoadBalancer, err)
+	}
+
+	return nil
+}
+
+func (c *nifcloudAPIClient) WaitElasticLoadBalancerApplied(ctx context.Context, elasticLoadBalancerName string) error {
+	waiter := computing.NewElasticLoadBalancerAvailableWaiter(c.client)
+	params := &computing.NiftyDescribeElasticLoadBalancersInput{
+		ElasticLoadBalancers: &types.RequestElasticLoadBalancers{
+			ListOfRequestElasticLoadBalancerName: []string{elasticLoadBalancerName},
+		},
+	}
+	if err := waiter.Wait(ctx, params, elasticLoadBalancerAppliedWaiterTimeout); err != nil {
+		return fmt.Errorf("failed waiting elastic load balancer: %w", err)
+	}
+	return nil
+}
+
+func (c *nifcloudAPIClient) DescribeSecurityGroups(ctx context.Context) ([]SecurityGroup, error) {
+	res, err := c.client.DescribeSecurityGroups(ctx, &computing.DescribeSecurityGroupsInput{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to request DescribeSecurityGroups: %w", err)
+	}
+
+	securityGroup := []SecurityGroup{}
+	for _, rs := range res.SecurityGroupInfo {
+		securityGroupRules := []SecurityGroupRule{}
+		for _, rule := range rs.IpPermissions {
+			ipRanges := []string{}
+			for _, ipRange := range rule.IpRanges {
+				ipRanges = append(ipRanges, nifcloud.ToString(ipRange.CidrIp))
+			}
+			securityGroupRules = append(securityGroupRules, SecurityGroupRule{
+				IpProtocol: nifcloud.ToString(rule.IpProtocol),
+				FromPort:   nifcloud.ToInt32(rule.FromPort),
+				ToPort:     nifcloud.ToInt32(rule.ToPort),
+				InOut:      nifcloud.ToString(rule.InOut),
+				IpRanges:   ipRanges,
+			})
+		}
+		securityGroup = append(securityGroup, SecurityGroup{
+			GroupName: nifcloud.ToString(rs.GroupName),
+			Rules:     securityGroupRules,
+		})
+	}
+
+	return securityGroup, nil
+}
+
+func (c *nifcloudAPIClient) DescribeSecurityGroupsByInstanceIDs(ctx context.Context, instanceIDs []string) ([]SecurityGroup, error) {
+	res, err := c.client.DescribeSecurityGroups(ctx, &computing.DescribeSecurityGroupsInput{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to request DescribeSecurityGroups: %w", err)
+	}
+
+	securityGroup := []SecurityGroup{}
+	for _, rs := range res.SecurityGroupInfo {
+		containTargetInstance := false
+		for _, instance := range rs.InstancesSet {
+			if slices.Contains(instanceIDs, nifcloud.ToString(instance.InstanceId)) {
+				containTargetInstance = true
+			}
+		}
+		if !containTargetInstance {
+			continue
+		}
+
+		securityGroupRules := []SecurityGroupRule{}
+		for _, rule := range rs.IpPermissions {
+			ipRanges := []string{}
+			for _, ipRange := range rule.IpRanges {
+				ipRanges = append(ipRanges, nifcloud.ToString(ipRange.CidrIp))
+			}
+			securityGroupRules = append(securityGroupRules, SecurityGroupRule{
+				IpProtocol: nifcloud.ToString(rule.IpProtocol),
+				FromPort:   nifcloud.ToInt32(rule.FromPort),
+				ToPort:     nifcloud.ToInt32(rule.ToPort),
+				InOut:      nifcloud.ToString(rule.InOut),
+				IpRanges:   ipRanges,
+			})
+		}
+		securityGroup = append(securityGroup, SecurityGroup{
+			GroupName: nifcloud.ToString(rs.GroupName),
+			Rules:     securityGroupRules,
+		})
+	}
+
+	return securityGroup, nil
+}
+
+func (c *nifcloudAPIClient) AuthorizeSecurityGroupIngress(ctx context.Context, securityGroupName string, securityGroupRule *SecurityGroupRule) error {
+	// TODO: Support for multiple securityGroupRules
+	ipRanges := []types.RequestIpRanges{}
+	for _, ipRange := range securityGroupRule.IpRanges {
+		ipRanges = append(ipRanges, types.RequestIpRanges{
+			CidrIp: &ipRange,
+		})
+	}
+
+	ipPermissions := []types.RequestIpPermissions{
+		{
+			IpProtocol:            types.IpProtocolOfIpPermissionsForAuthorizeSecurityGroupIngress(securityGroupRule.IpProtocol),
+			FromPort:              nifcloud.Int32(securityGroupRule.FromPort),
+			ToPort:                nifcloud.Int32(securityGroupRule.ToPort),
+			InOut:                 types.InOutOfIpPermissionsForAuthorizeSecurityGroupIngress(securityGroupRule.InOut),
+			ListOfRequestIpRanges: ipRanges,
+		},
+	}
+	if securityGroupRule.FromPort == securityGroupRule.ToPort {
+		ipPermissions[0].ToPort = nil
+	}
+
+	input := &computing.AuthorizeSecurityGroupIngressInput{
+		GroupName:     nifcloud.String(securityGroupName),
+		IpPermissions: ipPermissions,
+	}
+	res, err := c.client.AuthorizeSecurityGroupIngress(ctx, input)
+	if err != nil {
+		return fmt.Errorf("failed to request AuthorizeSecurityGroupIngress %s: %w", securityGroupRule, err)
+	}
+
+	if !nifcloud.ToBool(res.Return) {
+		return fmt.Errorf("failed to authorize security group rules %s", securityGroupRule)
+	}
+
+	return nil
+}
+
+func (c *nifcloudAPIClient) RevokeSecurityGroupIngress(ctx context.Context, securityGroupName string, securityGroupRule *SecurityGroupRule) error {
+	// TODO: Support for multiple securityGroupRules
+	ipRanges := []types.RequestIpRanges{}
+	for _, ipRange := range securityGroupRule.IpRanges {
+		ipRanges = append(ipRanges, types.RequestIpRanges{
+			CidrIp: &ipRange,
+		})
+	}
+	ipPermissions := []types.RequestIpPermissionsOfRevokeSecurityGroupIngress{
+		{
+			IpProtocol:            types.IpProtocolOfIpPermissionsForRevokeSecurityGroupIngress(securityGroupRule.IpProtocol),
+			FromPort:              nifcloud.Int32(securityGroupRule.FromPort),
+			ToPort:                nifcloud.Int32(securityGroupRule.ToPort),
+			InOut:                 types.InOutOfIpPermissionsForRevokeSecurityGroupIngress(securityGroupRule.InOut),
+			ListOfRequestIpRanges: ipRanges,
+		},
+	}
+	if securityGroupRule.FromPort == securityGroupRule.ToPort {
+		ipPermissions[0].ToPort = nil
+	}
+
+	input := &computing.RevokeSecurityGroupIngressInput{
+		GroupName:     nifcloud.String(securityGroupName),
+		IpPermissions: ipPermissions,
+	}
+	res, err := c.client.RevokeSecurityGroupIngress(ctx, input)
+	if err != nil {
+		return fmt.Errorf("failed to request RevokeSecurityGroupIngress %s: %w", securityGroupRule, err)
+	}
+
+	if !nifcloud.ToBool(res.Return) {
+		return fmt.Errorf("failed to revoke security group rules %s", securityGroupRule)
+	}
+
+	return nil
+}
+
+func (c *nifcloudAPIClient) WaitSecurityGroupApplied(ctx context.Context, securityGroupName string) error {
+	waiter := computing.NewSecurityGroupAppliedWaiter(c.client)
+	params := &computing.DescribeSecurityGroupsInput{GroupName: []string{securityGroupName}}
+	if err := waiter.Wait(ctx, params, securityGroupAppliedWaiterTimeout); err != nil {
+		return fmt.Errorf("failed waiting security group: %w", err)
+	}
 	return nil
 }

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
@@ -1,0 +1,700 @@
+package nifcloud
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	commonGlobalNetworkID  = "net-COMMON_GLOBAL"
+	commonPrivateNetworkID = "net-COMMON_PRIVATE"
+)
+
+func isElasticLoadBalancer(annotations map[string]string) bool {
+	return annotations[ServiceAnnotationLoadBalancerType] == "elb"
+}
+
+func isPrivateNetworkID(networkID string) bool {
+	return networkID != commonGlobalNetworkID && networkID != commonPrivateNetworkID
+}
+
+func (c *Cloud) getElasticLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {
+	// get load balancer name
+	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
+
+	// describe load balancer
+	loadBalancers, err := c.client.DescribeElasticLoadBalancers(ctx, loadBalancerName)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if len(loadBalancers) == 0 {
+		return nil, false, fmt.Errorf("not found load balancer: %q", loadBalancerName)
+	}
+
+	// return load balancer status
+	return toElasticLoadBalancerStatus(loadBalancers[0].VIP), true, nil
+}
+
+func (c *Cloud) getElasticLoadBalancerName(ctx context.Context, clusterName string, service *v1.Service) string {
+	return strings.Replace(string(service.UID), "-", "", -1)[:maxLoadBalancerNameLength]
+}
+
+func (c *Cloud) ensureElasticLoadBalancer(ctx context.Context, loadBalancerName string, desire []ElasticLoadBalancer) (*v1.LoadBalancerStatus, error) {
+	// TODO: Add Validation
+	// correct state differences
+	if len(desire) == 0 {
+		return nil, fmt.Errorf("desire ElasticLoadBalancer length must be larger than 1")
+	}
+
+	// get current load balancer status
+	current, err := c.client.DescribeElasticLoadBalancers(ctx, loadBalancerName)
+
+	// if not exist, create load balancer
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") {
+			// create all load balancers
+			var vip string
+			var networkInterface []NetworkInterface
+			for i, lb := range desire {
+				klog.Infof("Creating ElasticLoadBalancer %q (%d -> %d)", lb.Name, lb.LoadBalancerPort, lb.InstancePort)
+				if i == 0 {
+					_, err = c.client.CreateElasticLoadBalancer(ctx, &lb)
+					if err != nil {
+						return nil, fmt.Errorf("failed to create elastic load balancer: %w", err)
+					}
+					current, err = c.client.DescribeElasticLoadBalancers(ctx, loadBalancerName)
+					if err != nil {
+						return nil, fmt.Errorf("failed to describe elastic load balancer %q: %w", loadBalancerName, err)
+					}
+					vip = current[0].VIP
+					networkInterface = current[0].NetworkInterface
+				} else {
+					if err := c.client.RegisterPortWithElasticLoadBalancer(ctx, &lb); err != nil {
+						return nil, fmt.Errorf("failed to add port to elastic load balancer: %w", err)
+					}
+				}
+				lb.VIP = vip
+				lb.NetworkInterface = networkInterface
+				if err := c.allowSecurityGroupRulesFromElasticLoadBalancer(ctx, &lb, lb.BalancingTargets); err != nil {
+					return nil, fmt.Errorf("failed to allow security group rules from elastic load balancer: %w", err)
+				}
+			}
+			return toElasticLoadBalancerStatus(vip), nil
+		}
+		return nil, fmt.Errorf("failed to describe elastic load balancer %q: %w", loadBalancerName, err)
+	}
+
+	// if exist, configure load balancers
+
+	for i := range desire {
+		desire[i].VIP = current[0].VIP
+		desire[i].NetworkInterface = current[0].NetworkInterface
+	}
+
+	loadBalancerResourceChanged := false
+
+	// if need to register port
+	toCreate := elasticLoadBalancerDifferences(desire, current)
+	for _, lb := range toCreate {
+		klog.Infof("Registering ElasticLoadBalancer port %q (%d -> %d)", lb.Name, lb.LoadBalancerPort, lb.InstancePort)
+		if err := c.client.RegisterPortWithElasticLoadBalancer(ctx, &lb); err != nil {
+			return nil, fmt.Errorf("failed to add port to elastic load balancer: %w", err)
+		}
+		loadBalancerResourceChanged = true
+		if err := c.allowSecurityGroupRulesFromElasticLoadBalancer(ctx, &lb, lb.BalancingTargets); err != nil {
+			return nil, fmt.Errorf("failed to allow security group rules from elastic load balancer: %w", err)
+		}
+	}
+
+	// if need to delete port
+	toDelete := elasticLoadBalancerDifferences(current, desire)
+	for _, lb := range toDelete {
+		klog.Infof("Deleting LoadBalancer %q (%d -> %d)", lb.Name, lb.LoadBalancerPort, lb.InstancePort)
+		if err := c.client.DeleteElasticLoadBalancer(ctx, &lb); err != nil {
+			return nil, fmt.Errorf("failed to delete elastic load balancer: %w", err)
+		}
+		loadBalancerResourceChanged = true
+		if err := c.denySecurityGroupRulesFromElasticLoadBalancer(ctx, &lb, lb.BalancingTargets); err != nil {
+			return nil, fmt.Errorf("failed to deny security group rules from elastic load balancer: %w", err)
+		}
+	}
+
+	if loadBalancerResourceChanged {
+		current, err = c.client.DescribeElasticLoadBalancers(ctx, loadBalancerName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to describe elastic load balancer %q: %w", loadBalancerName, err)
+		}
+	}
+
+	for _, currentLB := range current {
+		desireLB, err := findElasticLoadBalancer(desire, currentLB)
+		if err != nil {
+			return nil, err
+		}
+
+		// reconcile balancing targets
+		toRegister := elasticLoadBalancingTargetsDifferences(desireLB.BalancingTargets, currentLB.BalancingTargets)
+		if len(toRegister) > 0 {
+			klog.Infof(
+				"Register instances with elastic load balancer %q (%d -> %d): %v",
+				currentLB.Name, currentLB.LoadBalancerPort, currentLB.InstancePort, toRegister,
+			)
+			if err := c.client.RegisterInstancesWithElasticLoadBalancer(ctx, &currentLB, toRegister); err != nil {
+				return nil, fmt.Errorf("failed to register instances: %w", err)
+			}
+			if err := c.allowSecurityGroupRulesFromElasticLoadBalancer(ctx, &currentLB, toRegister); err != nil {
+				return nil, fmt.Errorf("failed to allow security group rules from elastic load balancer: %w", err)
+			}
+		}
+
+		toDeregister := elasticLoadBalancingTargetsDifferences(currentLB.BalancingTargets, desireLB.BalancingTargets)
+		if len(toDeregister) > 0 {
+			klog.Infof(
+				"Deregister instances from load balancer %q (%d -> %d): %v",
+				currentLB.Name, currentLB.LoadBalancerPort, currentLB.InstancePort, toDeregister,
+			)
+			if err := c.client.DeregisterInstancesFromElasticLoadBalancer(ctx, &currentLB, toDeregister); err != nil {
+				return nil, fmt.Errorf("failed to deregister instances: %w", err)
+			}
+			if err := c.denySecurityGroupRulesFromElasticLoadBalancer(ctx, &currentLB, toRegister); err != nil {
+				return nil, fmt.Errorf("failed to deny security group rules from elastic load balancer: %w", err)
+			}
+		}
+	}
+
+	return toElasticLoadBalancerStatus(current[0].VIP), nil
+}
+
+func NewElasticLoadBalancerFromService(loadBalancerName string, instances []Instance, service *v1.Service) ([]ElasticLoadBalancer, error) {
+	// TODO: validation
+	portCount := len(service.Spec.Ports)
+
+	// detect state differences
+	desire := make([]ElasticLoadBalancer, portCount)
+	annotations := service.Annotations
+
+	// load balancer name
+	for i := range desire {
+		desire[i].Name = loadBalancerName
+	}
+
+	// Availability zones
+	for i := range desire {
+		desire[i].AvailabilityZone = instances[0].Zone
+	}
+
+	// balancing type
+	if rawBalancingType, ok := annotations[ServiceAnnotationLoadBalancerBalancingType]; ok {
+		balancingType, err := strconv.Atoi(rawBalancingType)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"balancing type %q is invalid for service %q: %v",
+				rawBalancingType, service.GetName(), err,
+			)
+		}
+		for i := range desire {
+			desire[i].BalancingType = int32(balancingType)
+		}
+	}
+
+	// accounting type
+	if accountingType, ok := annotations[ServiceAnnotationLoadBalancerAccountingType]; ok {
+		for i := range desire {
+			desire[i].AccountingType = accountingType
+		}
+	}
+
+	// network volume
+	if networkVolume, ok := annotations[ServiceAnnotationLoadBalancerNetworkVolume]; ok {
+		v, err := strconv.Atoi(networkVolume)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"network volume %q is invalid for service %q: %v",
+				networkVolume, service.GetName(), err,
+			)
+		}
+		for i := range desire {
+			desire[i].NetworkVolume = int32(v)
+		}
+	}
+
+	// protocol
+	for i, port := range service.Spec.Ports {
+		if port.Protocol != v1.ProtocolTCP {
+			return nil, fmt.Errorf("only TCP load balancer is supported")
+		}
+		desire[i].Protocol = "TCP"
+		if port.NodePort == 0 {
+			klog.Errorf("Ignoring port without NodePort defined: %v", port)
+			continue
+		}
+	}
+
+	// load balancer port
+	for i, port := range service.Spec.Ports {
+		desire[i].LoadBalancerPort = int32(port.Port)
+	}
+
+	// instance port
+	for i, port := range service.Spec.Ports {
+		desire[i].InstancePort = int32(port.NodePort)
+	}
+
+	// health check interval
+	if strInterval, ok := annotations[ServiceAnnotationLoadBalancerHCInterval]; ok {
+		interval, err := strconv.Atoi(strInterval)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"health check interval %q is invalid for service %q: %v",
+				strInterval, service.GetName(), err,
+			)
+		}
+		for i := range desire {
+			desire[i].HealthCheckInterval = int32(interval)
+		}
+	} else {
+		for i := range desire {
+			desire[i].HealthCheckInterval = defaultHealthCheckInterval
+		}
+	}
+
+	// unhealthy threshold
+	if unhealthyThreshold, ok := annotations[ServiceAnnotationLoadBalancerHCUnhealthyThreshold]; ok {
+		t, err := strconv.Atoi(unhealthyThreshold)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unhealthy threshold %q is invalid for service %q: %v",
+				unhealthyThreshold, service.GetName(), err,
+			)
+		}
+		for i := range desire {
+			desire[i].HealthCheckUnhealthyThreshold = int32(t)
+		}
+	} else {
+		for i := range desire {
+			desire[i].HealthCheckUnhealthyThreshold = defaultHealthCheckUnhealthyThreshold
+		}
+	}
+
+	// health check target
+	if proto, ok := annotations[ServiceAnnotationLoadBalancerHCProtocol]; ok {
+		switch strings.ToUpper(proto) {
+		case "TCP":
+			for i, port := range service.Spec.Ports {
+				desire[i].HealthCheckTarget = fmt.Sprintf("TCP:%d", port.NodePort)
+			}
+		case "ICMP":
+			for i := range desire {
+				desire[i].HealthCheckTarget = "ICMP"
+			}
+		default:
+			return nil, fmt.Errorf(
+				"health check protocol %q is invalid for service %q",
+				proto, service.GetName(),
+			)
+		}
+	} else {
+		for i, port := range service.Spec.Ports {
+			desire[i].HealthCheckTarget = fmt.Sprintf("%s:%d", defaultHealthCheckTarget, port.NodePort)
+		}
+	}
+
+	// balancing targets
+	for i := range desire {
+		desire[i].BalancingTargets = instances
+	}
+
+	// network interfaces
+	networkInterfaces := []NetworkInterface{}
+	if networkInterface1, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1]; ok {
+		networkInterface := NetworkInterface{
+			NetworkId: networkInterface1,
+		}
+
+		if ipAddress, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1IPAddress]; ok {
+			networkInterface.IPAddress = ipAddress
+		}
+
+		if isPrivateNetworkID(networkInterface.NetworkId) {
+			systemIPAdresses := []string{}
+			if systemIPAddress1, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddress1]; ok {
+				systemIPAdresses = append(systemIPAdresses, systemIPAddress1)
+			}
+			if systemIPAddress2, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddress2]; ok {
+				systemIPAdresses = append(systemIPAdresses, systemIPAddress2)
+			}
+			if len(systemIPAdresses) == 2 {
+				networkInterface.SystemIpAddresses = systemIPAdresses
+			} else {
+				return nil, fmt.Errorf("system ip address require two value")
+			}
+		}
+
+		if vipNetwork, ok := annotations[ServiceAnnotationLoadBalancerVipNetwork]; ok {
+			if vipNetwork == "1" {
+				networkInterface.IsVipNetwork = true
+			}
+		}
+
+		networkInterfaces = append(networkInterfaces, networkInterface)
+	}
+
+	if networkInterface2, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2]; ok {
+		networkInterface := NetworkInterface{
+			NetworkId: networkInterface2,
+		}
+
+		if ipAddress, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2IPAddress]; ok {
+			networkInterface.IPAddress = ipAddress
+		}
+
+		if isPrivateNetworkID(networkInterface.NetworkId) {
+			systemIPAdresses := []string{}
+			if systemIPAddress1, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddress1]; ok {
+				systemIPAdresses = append(systemIPAdresses, systemIPAddress1)
+			}
+			if systemIPAddress2, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddress2]; ok {
+				systemIPAdresses = append(systemIPAdresses, systemIPAddress2)
+			}
+			if len(systemIPAdresses) == 2 {
+				networkInterface.SystemIpAddresses = systemIPAdresses
+			} else {
+				return nil, fmt.Errorf("system ip address require two value")
+			}
+		}
+
+		if vipNetwork, ok := annotations[ServiceAnnotationLoadBalancerVipNetwork]; ok {
+			if vipNetwork == "2" {
+				networkInterface.IsVipNetwork = true
+			}
+		}
+
+		networkInterfaces = append(networkInterfaces, networkInterface)
+	}
+
+	if len(networkInterfaces) == 1 || len(networkInterfaces) == 2 {
+		for i := range desire {
+			desire[i].NetworkInterface = networkInterfaces
+		}
+	} else {
+		networkInterface := NetworkInterface{
+			NetworkId:    defaultNetworkInterface,
+			IsVipNetwork: true,
+		}
+		for i := range desire {
+			desire[i].NetworkInterface = append(desire[i].NetworkInterface, networkInterface)
+		}
+	}
+
+	return desire, nil
+}
+
+func (c *Cloud) allowSecurityGroupRulesFromElasticLoadBalancer(ctx context.Context, elasticLoadBalancer *ElasticLoadBalancer, instances []Instance) error {
+	instanceIDs := []string{}
+	for _, instance := range instances {
+		instanceIDs = append(instanceIDs, instance.InstanceID)
+	}
+
+	securityGroups, err := c.client.DescribeSecurityGroupsByInstanceIDs(ctx, instanceIDs)
+	if err != nil {
+		return err
+	}
+
+	securityGroupRules, err := c.securityGroupRulesOfElasticLoadBalancer(ctx, elasticLoadBalancer)
+	if err != nil {
+		return err
+	}
+
+	for _, securityGroup := range securityGroups {
+		for _, securityGroupRule := range securityGroupRules {
+			err = c.client.AuthorizeSecurityGroupIngress(ctx, securityGroup.GroupName, &securityGroupRule)
+			if err != nil {
+				if strings.Contains(err.Error(), "Client.InvalidParameterDuplicate.SecurityGroup") {
+					// ignore error
+				} else {
+					return err
+				}
+			}
+			err = c.client.WaitSecurityGroupApplied(ctx, securityGroup.GroupName)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Cloud) denySecurityGroupRulesFromElasticLoadBalancer(ctx context.Context, elasticLoadBalancer *ElasticLoadBalancer, instances []Instance) error {
+	instanceIDs := []string{}
+	for _, instance := range instances {
+		instanceIDs = append(instanceIDs, instance.InstanceID)
+	}
+
+	securityGroups, err := c.client.DescribeSecurityGroupsByInstanceIDs(ctx, instanceIDs)
+	if err != nil {
+		return err
+	}
+
+	securityGroupRules, err := c.securityGroupRulesOfElasticLoadBalancer(ctx, elasticLoadBalancer)
+	if err != nil {
+		return err
+	}
+
+	for _, securityGroup := range securityGroups {
+		for _, securityGroupRule := range securityGroupRules {
+			err = c.client.RevokeSecurityGroupIngress(ctx, securityGroup.GroupName, &securityGroupRule)
+			if err != nil {
+				if strings.Contains(err.Error(), "Client.InvalidParameterNotFound.SecurityGroupIngress") {
+					// ignore error
+				} else {
+					return err
+				}
+			}
+			err = c.client.WaitSecurityGroupApplied(ctx, securityGroup.GroupName)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Cloud) securityGroupRulesOfElasticLoadBalancer(ctx context.Context, elasticLoadBalancer *ElasticLoadBalancer) ([]SecurityGroupRule, error) {
+	securityGroupRules := []SecurityGroupRule{}
+	VIPRanges := []string{elasticLoadBalancer.VIP}
+
+	healthCheckProtocol, _ := separateHealthCheckTarget(elasticLoadBalancer.HealthCheckTarget)
+
+	if len(elasticLoadBalancer.NetworkInterface) == 1 {
+		// one arm
+		securityGroupRule := SecurityGroupRule{
+			IpProtocol: elasticLoadBalancer.Protocol,
+			FromPort:   elasticLoadBalancer.InstancePort,
+			ToPort:     elasticLoadBalancer.InstancePort,
+			InOut:      "IN",
+			IpRanges:   VIPRanges,
+		}
+		securityGroupRules = append(securityGroupRules, securityGroupRule)
+
+		if healthCheckProtocol == "ICMP" {
+			IPAddressRule := SecurityGroupRule{
+				IpProtocol: healthCheckProtocol,
+				InOut:      "IN",
+				IpRanges:   VIPRanges,
+			}
+			securityGroupRules = append(securityGroupRules, IPAddressRule)
+			for _, systemIPAddress := range elasticLoadBalancer.NetworkInterface[0].SystemIpAddresses {
+				systemIPAddressRule := SecurityGroupRule{
+					IpProtocol: healthCheckProtocol,
+					InOut:      "IN",
+					IpRanges:   []string{systemIPAddress},
+				}
+				securityGroupRules = append(securityGroupRules, systemIPAddressRule)
+			}
+		} else {
+			if elasticLoadBalancer.Protocol != healthCheckProtocol {
+				IPAddressRule := SecurityGroupRule{
+					IpProtocol: healthCheckProtocol,
+					FromPort:   elasticLoadBalancer.InstancePort,
+					ToPort:     elasticLoadBalancer.InstancePort,
+					InOut:      "IN",
+					IpRanges:   VIPRanges,
+				}
+				securityGroupRules = append(securityGroupRules, IPAddressRule)
+			}
+			for _, systemIPAddress := range elasticLoadBalancer.NetworkInterface[0].SystemIpAddresses {
+				systemIPAddressRule := SecurityGroupRule{
+					IpProtocol: healthCheckProtocol,
+					FromPort:   elasticLoadBalancer.InstancePort,
+					ToPort:     elasticLoadBalancer.InstancePort,
+					InOut:      "IN",
+					IpRanges:   []string{systemIPAddress},
+				}
+				securityGroupRules = append(securityGroupRules, systemIPAddressRule)
+			}
+		}
+
+	} else if len(elasticLoadBalancer.NetworkInterface) == 2 {
+		// two arm
+		if healthCheckProtocol == "ICMP" {
+			var notVIPNetworkInterface NetworkInterface
+			if elasticLoadBalancer.NetworkInterface[0].IsVipNetwork {
+				notVIPNetworkInterface = elasticLoadBalancer.NetworkInterface[1]
+			} else {
+				notVIPNetworkInterface = elasticLoadBalancer.NetworkInterface[0]
+			}
+
+			IPAddressRule := SecurityGroupRule{
+				IpProtocol: healthCheckProtocol,
+				InOut:      "IN",
+				IpRanges:   []string{notVIPNetworkInterface.IPAddress},
+			}
+			securityGroupRules = append(securityGroupRules, IPAddressRule)
+
+			for _, systemIPAddress := range notVIPNetworkInterface.SystemIpAddresses {
+				systemIPAddressRule := SecurityGroupRule{
+					IpProtocol: healthCheckProtocol,
+					InOut:      "IN",
+					IpRanges:   []string{systemIPAddress},
+				}
+				securityGroupRules = append(securityGroupRules, systemIPAddressRule)
+			}
+		} else {
+			var notVIPNetworkInterface NetworkInterface
+			if elasticLoadBalancer.NetworkInterface[0].IsVipNetwork {
+				notVIPNetworkInterface = elasticLoadBalancer.NetworkInterface[1]
+			} else {
+				notVIPNetworkInterface = elasticLoadBalancer.NetworkInterface[0]
+			}
+
+			IPAddressRule := SecurityGroupRule{
+				IpProtocol: healthCheckProtocol,
+				FromPort:   elasticLoadBalancer.InstancePort,
+				ToPort:     elasticLoadBalancer.InstancePort,
+				InOut:      "IN",
+				IpRanges:   []string{notVIPNetworkInterface.IPAddress},
+			}
+			securityGroupRules = append(securityGroupRules, IPAddressRule)
+
+			for _, systemIPAddress := range notVIPNetworkInterface.SystemIpAddresses {
+				systemIPAddressRule := SecurityGroupRule{
+					IpProtocol: healthCheckProtocol,
+					FromPort:   elasticLoadBalancer.InstancePort,
+					ToPort:     elasticLoadBalancer.InstancePort,
+					InOut:      "IN",
+					IpRanges:   []string{systemIPAddress},
+				}
+				securityGroupRules = append(securityGroupRules, systemIPAddressRule)
+			}
+		}
+	} else {
+		return nil, fmt.Errorf("the number of NetworkInterfaces (%d) is invalid", len(elasticLoadBalancer.NetworkInterface))
+	}
+
+	return securityGroupRules, nil
+}
+
+func separateHealthCheckTarget(healthCheckTarget string) (string, string) {
+	if healthCheckTarget == "ICMP" {
+		return "ICMP", ""
+	}
+	r := regexp.MustCompile("^(TCP|HTTP|HTTPS):([0-9]+)$")
+	match := r.FindStringSubmatch(healthCheckTarget)
+	return match[1], match[2]
+}
+
+func (c *Cloud) updateElasticLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) error {
+	// get elastic load balancer name
+	loadBalancerName := c.getElasticLoadBalancerName(ctx, clusterName, service)
+
+	// describe load balancer
+	loadBalancers, err := c.client.DescribeElasticLoadBalancers(ctx, loadBalancerName)
+	if err != nil {
+		return err
+	}
+	if len(loadBalancers) == 0 {
+		return fmt.Errorf("load balancer %q not found", loadBalancerName)
+	}
+
+	// ensure load balancer
+	_, err = c.EnsureLoadBalancer(ctx, clusterName, service, nodes)
+
+	return err
+}
+
+func (c *Cloud) ensureElasticLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {
+	// get elastic load balancer name
+	loadBalancerName := c.getElasticLoadBalancerName(ctx, clusterName, service)
+
+	// describe load balancer
+	loadBalancers, err := c.client.DescribeElasticLoadBalancers(ctx, loadBalancerName)
+	if err != nil {
+		return err
+	}
+	if len(loadBalancers) == 0 {
+		return fmt.Errorf("load balancer %q already deleted", loadBalancerName)
+	}
+
+	// delete load balancer
+	for _, lb := range loadBalancers {
+		klog.Infof("Deleting LoadBalancer %q (%d -> %d)", lb.Name, lb.LoadBalancerPort, lb.InstancePort)
+		if err := c.client.DeleteElasticLoadBalancer(ctx, &lb); err != nil {
+			return fmt.Errorf("failed to delete load balancer: %w", err)
+		}
+		if err := c.denySecurityGroupRulesFromElasticLoadBalancer(ctx, &lb, lb.BalancingTargets); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func findElasticLoadBalancer(from []ElasticLoadBalancer, target ElasticLoadBalancer) (*ElasticLoadBalancer, error) {
+	for _, lb := range from {
+		if target.Equals(lb) {
+			return &lb, nil
+		}
+	}
+
+	return nil, fmt.Errorf(
+		"target load balancer (%q: %d -> %d) not found",
+		target.Name, target.LoadBalancerPort, target.InstancePort,
+	)
+}
+
+func elasticLoadBalancerDifferences(target, other []ElasticLoadBalancer) []ElasticLoadBalancer {
+	diff := []ElasticLoadBalancer{}
+	for _, x := range target {
+		found := false
+		for _, y := range other {
+			if x.Equals(y) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			diff = append(diff, x)
+		}
+	}
+
+	return diff
+}
+
+func elasticLoadBalancingTargetsDifferences(target, other []Instance) []Instance {
+	diff := []Instance{}
+	for _, x := range target {
+		found := false
+		for _, y := range other {
+			if x.Equals(y) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			diff = append(diff, x)
+		}
+	}
+
+	return diff
+}
+
+func toElasticLoadBalancerStatus(vip string) *v1.LoadBalancerStatus {
+	return &v1.LoadBalancerStatus{
+		Ingress: []v1.LoadBalancerIngress{
+			{
+				IP: vip,
+			},
+		},
+	}
+}

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
@@ -385,7 +385,7 @@ func NewElasticLoadBalancerFromService(loadBalancerName string, instances []Inst
 		}
 	} else {
 		networkInterface := NetworkInterface{
-			NetworkId:    defaultNetworkInterface,
+			NetworkId:    elasticLoadBalancerDefaultNetworkInterface,
 			IsVipNetwork: true,
 		}
 		for i := range desire {

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
@@ -20,7 +20,7 @@ func isElasticLoadBalancer(annotations map[string]string) bool {
 	return annotations[ServiceAnnotationLoadBalancerType] == "elb"
 }
 
-func isPrivateNetworkID(networkID string) bool {
+func isPrivateLanNetworkID(networkID string) bool {
 	return networkID != commonGlobalNetworkID && networkID != commonPrivateNetworkID
 }
 
@@ -322,7 +322,7 @@ func NewElasticLoadBalancerFromService(loadBalancerName string, instances []Inst
 			networkInterface.IPAddress = ipAddress
 		}
 
-		if isPrivateNetworkID(networkInterface.NetworkId) {
+		if isPrivateLanNetworkID(networkInterface.NetworkId) {
 			separatedSystemIPAdresses := []string{}
 			if systemIPAddresses, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses]; ok {
 				separatedSystemIPAdresses = strings.Split(systemIPAddresses, ",")
@@ -352,7 +352,7 @@ func NewElasticLoadBalancerFromService(loadBalancerName string, instances []Inst
 			networkInterface.IPAddress = ipAddress
 		}
 
-		if isPrivateNetworkID(networkInterface.NetworkId) {
+		if isPrivateLanNetworkID(networkInterface.NetworkId) {
 			separatedSystemIPAdresses := []string{}
 			if systemIPAddresses, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses]; ok {
 				separatedSystemIPAdresses = strings.Split(systemIPAddresses, ",")

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
@@ -39,7 +39,7 @@ func (c *Cloud) getElasticLoadBalancer(ctx context.Context, clusterName string, 
 	}
 
 	// return load balancer status
-	return toElasticLoadBalancerStatus(loadBalancers[0].VIP), true, nil
+	return toLoadBalancerStatus(loadBalancers[0].VIP), true, nil
 }
 
 func (c *Cloud) getElasticLoadBalancerName(ctx context.Context, clusterName string, service *v1.Service) string {
@@ -86,7 +86,7 @@ func (c *Cloud) ensureElasticLoadBalancer(ctx context.Context, loadBalancerName 
 					return nil, fmt.Errorf("failed to allow security group rules from elastic load balancer: %w", err)
 				}
 			}
-			return toElasticLoadBalancerStatus(vip), nil
+			return toLoadBalancerStatus(vip), nil
 		}
 		return nil, fmt.Errorf("failed to describe elastic load balancer %q: %w", loadBalancerName, err)
 	}
@@ -169,7 +169,7 @@ func (c *Cloud) ensureElasticLoadBalancer(ctx context.Context, loadBalancerName 
 		}
 	}
 
-	return toElasticLoadBalancerStatus(current[0].VIP), nil
+	return toLoadBalancerStatus(current[0].VIP), nil
 }
 
 func NewElasticLoadBalancerFromService(loadBalancerName string, instances []Instance, service *v1.Service) ([]ElasticLoadBalancer, error) {
@@ -681,14 +681,4 @@ func elasticLoadBalancingTargetsDifferences(target, other []Instance) []Instance
 	}
 
 	return diff
-}
-
-func toElasticLoadBalancerStatus(vip string) *v1.LoadBalancerStatus {
-	return &v1.LoadBalancerStatus{
-		Ingress: []v1.LoadBalancerIngress{
-			{
-				IP: vip,
-			},
-		},
-	}
 }

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
@@ -323,15 +323,12 @@ func NewElasticLoadBalancerFromService(loadBalancerName string, instances []Inst
 		}
 
 		if isPrivateNetworkID(networkInterface.NetworkId) {
-			systemIPAdresses := []string{}
-			if systemIPAddress1, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddress1]; ok {
-				systemIPAdresses = append(systemIPAdresses, systemIPAddress1)
+			separatedSystemIPAdresses := []string{}
+			if systemIPAddresses, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses]; ok {
+				separatedSystemIPAdresses = strings.Split(systemIPAddresses, ",")
 			}
-			if systemIPAddress2, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddress2]; ok {
-				systemIPAdresses = append(systemIPAdresses, systemIPAddress2)
-			}
-			if len(systemIPAdresses) == 2 {
-				networkInterface.SystemIpAddresses = systemIPAdresses
+			if len(separatedSystemIPAdresses) == 2 {
+				networkInterface.SystemIpAddresses = separatedSystemIPAdresses
 			} else {
 				return nil, fmt.Errorf("system ip address require two value")
 			}
@@ -356,15 +353,12 @@ func NewElasticLoadBalancerFromService(loadBalancerName string, instances []Inst
 		}
 
 		if isPrivateNetworkID(networkInterface.NetworkId) {
-			systemIPAdresses := []string{}
-			if systemIPAddress1, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddress1]; ok {
-				systemIPAdresses = append(systemIPAdresses, systemIPAddress1)
+			separatedSystemIPAdresses := []string{}
+			if systemIPAddresses, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses]; ok {
+				separatedSystemIPAdresses = strings.Split(systemIPAddresses, ",")
 			}
-			if systemIPAddress2, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddress2]; ok {
-				systemIPAdresses = append(systemIPAdresses, systemIPAddress2)
-			}
-			if len(systemIPAdresses) == 2 {
-				networkInterface.SystemIpAddresses = systemIPAdresses
+			if len(separatedSystemIPAdresses) == 2 {
+				networkInterface.SystemIpAddresses = separatedSystemIPAdresses
 			} else {
 				return nil, fmt.Errorf("system ip address require two value")
 			}

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
@@ -35,7 +35,7 @@ func (c *Cloud) getElasticLoadBalancer(ctx context.Context, clusterName string, 
 	}
 
 	if len(loadBalancers) == 0 {
-		return nil, false, fmt.Errorf("not found load balancer: %q", loadBalancerName)
+		return nil, false, fmt.Errorf("not found elastic load balancer: %q", loadBalancerName)
 	}
 
 	// return load balancer status

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
@@ -65,8 +65,8 @@ const (
 
 	// ServiceAnnotationLoadBalancerNetworkInterface(1-2) is the annotation that specify network interface of elastic load balancer
 	// net-COMMON_GLOBAL, net-COMMON_PRIVATE or network ID of private LAN
-	ServiceAnnotationLoadBalancerNetworkInterface1 = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-1"
-	ServiceAnnotationLoadBalancerNetworkInterface2 = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-2"
+	ServiceAnnotationLoadBalancerNetworkInterface1 = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-1-network-id"
+	ServiceAnnotationLoadBalancerNetworkInterface2 = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-2-network-id"
 
 	// ServiceAnnotationLoadBalancerNetworkInterface(1-2)IPAddress is the annotation that specify IPAdress of elastic load balancer
 	// Set IP address only when corresponding network interface is private

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
@@ -73,12 +73,10 @@ const (
 	ServiceAnnotationLoadBalancerNetworkInterface1IPAddress = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-1-ip-address"
 	ServiceAnnotationLoadBalancerNetworkInterface2IPAddress = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-2-ip-address"
 
-	// ServiceAnnotationLoadBalancerNetworkInterface(1-2)SystemIPAddress(1-2) is the annotation that specify SystemIPAdress of elastic load balancer
+	// ServiceAnnotationLoadBalancerNetworkInterface(1-2)SystemIPAddresses is the annotation that specify SystemIPAdresses of elastic load balancer
 	// Set system IP address only when corresponding network interface is private
-	ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddress1 = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-1-system-ip-address-1"
-	ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddress2 = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-1-system-ip-address-2"
-	ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddress1 = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-2-system-ip-address-1"
-	ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddress2 = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-2-system-ip-address-2"
+	ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-1-system-ip-addresses"
+	ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-2-system-ip-addresses"
 
 	// ServiceAnnotationLoadBalancerVipNetwork is the annotation that specify VIP network
 	// valid values are '1' or '2'

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
@@ -23,7 +23,7 @@ const (
 	defaultHealthCheckTarget             = "TCP"
 
 	// default network interface
-	defaultNetworkInterface = "net-COMMON_GLOBAL"
+	elasticLoadBalancerDefaultNetworkInterface = commonGlobalNetworkID
 
 	// ServiceAnnotationLoadBalancerNetworkVolume is the annotation that specify network volume for load balancer
 	// valid volume is 10, 20, ..., 2000

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
@@ -14,13 +14,16 @@ import (
 
 const (
 	// limits for NIFCLOUD load balancer
-	maxLoadBalanacerNameLength  = 15
+	maxLoadBalancerNameLength   = 15
 	maxPortCountPerLoadBalancer = 3
 
 	// default health check parameter values
 	defaultHealthCheckInterval           = 10
 	defaultHealthCheckUnhealthyThreshold = 1
 	defaultHealthCheckTarget             = "TCP"
+
+	// default network interface
+	defaultNetworkInterface = "net-COMMON_GLOBAL"
 
 	// ServiceAnnotationLoadBalancerNetworkVolume is the annotation that specify network volume for load balancer
 	// valid volume is 10, 20, ..., 2000
@@ -55,10 +58,39 @@ const (
 	// ServiceAnnotationLoadBalancerHCInterval is the annotation that specify interval seconds for health check
 	// See https://pfs.nifcloud.com/api/rest/ConfigureHealthCheck.htm
 	ServiceAnnotationLoadBalancerHCInterval = "service.beta.kubernetes.io/nifcloud-load-balancer-healthcheck-interval"
+
+	// ServiceAnnotationLoadBalancerType is the annotation that specify using load balancer type
+	// valid values are 'lb' or 'elb'
+	ServiceAnnotationLoadBalancerType = "service.beta.kubernetes.io/nifcloud-load-balancer-type"
+
+	// ServiceAnnotationLoadBalancerNetworkInterface(1-2) is the annotation that specify network interface of elastic load balancer
+	// net-COMMON_GLOBAL, net-COMMON_PRIVATE or network ID of private LAN
+	ServiceAnnotationLoadBalancerNetworkInterface1 = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-1"
+	ServiceAnnotationLoadBalancerNetworkInterface2 = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-2"
+
+	// ServiceAnnotationLoadBalancerNetworkInterface(1-2)IPAddress is the annotation that specify IPAdress of elastic load balancer
+	// Set IP address only when corresponding network interface is private
+	ServiceAnnotationLoadBalancerNetworkInterface1IPAddress = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-1-ip-address"
+	ServiceAnnotationLoadBalancerNetworkInterface2IPAddress = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-2-ip-address"
+
+	// ServiceAnnotationLoadBalancerNetworkInterface(1-2)SystemIPAddress(1-2) is the annotation that specify SystemIPAdress of elastic load balancer
+	// Set system IP address only when corresponding network interface is private
+	ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddress1 = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-1-system-ip-address-1"
+	ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddress2 = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-1-system-ip-address-2"
+	ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddress1 = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-2-system-ip-address-1"
+	ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddress2 = "service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-2-system-ip-address-2"
+
+	// ServiceAnnotationLoadBalancerVipNetwork is the annotation that specify VIP network
+	// valid values are '1' or '2'
+	ServiceAnnotationLoadBalancerVipNetwork = "service.beta.kubernetes.io/nifcloud-load-balancer-vip-network"
 )
 
 // GetLoadBalancer returns whether the specified load balancer exists, and if so, what its status is
 func (c *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {
+	if isElasticLoadBalancer(service.Annotations) {
+		return c.getElasticLoadBalancer(ctx, clusterName, service)
+	}
+
 	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
 	loadBalancers, err := c.client.DescribeLoadBalancers(ctx, loadBalancerName)
 	if err != nil {
@@ -75,7 +107,7 @@ func (c *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, service
 
 // GetLoadBalancerName returns the name of the load balancer
 func (c *Cloud) GetLoadBalancerName(ctx context.Context, clusterName string, service *v1.Service) string {
-	return strings.Replace(string(service.UID), "-", "", -1)[:maxLoadBalanacerNameLength]
+	return strings.Replace(string(service.UID), "-", "", -1)[:maxLoadBalancerNameLength]
 }
 
 // EnsureLoadBalancer creates a new load balancer 'name', or updates the existing one. Returns the status of the balancer
@@ -101,121 +133,133 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, serv
 		return nil, fmt.Errorf("could not fetch instances info for %v: %v", instanceIDs, err)
 	}
 
-	desire := make([]LoadBalancer, portCount)
 	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
-	for i, port := range service.Spec.Ports {
-		// basic load balancer options
-		desire[i].Name = loadBalancerName
-		annotations := service.Annotations
-		if rawBalancingType, ok := annotations[ServiceAnnotationLoadBalancerBalancingType]; ok {
-			balancingType, err := strconv.Atoi(rawBalancingType)
-			if err != nil {
-				return nil, fmt.Errorf(
-					"balancing type %q is invalid for service %q: %v",
-					rawBalancingType, service.GetName(), err,
-				)
-			}
-			desire[i].BalancingType = int32(balancingType)
-		}
 
-		if accountingType, ok := annotations[ServiceAnnotationLoadBalancerAccountingType]; ok {
-			desire[i].AccountingType = accountingType
-		}
-
-		if networkVolume, ok := annotations[ServiceAnnotationLoadBalancerNetworkVolume]; ok {
-			v, err := strconv.Atoi(networkVolume)
-			if err != nil {
-				return nil, fmt.Errorf(
-					"network volume %q is invalid for service %q: %v",
-					networkVolume, service.GetName(), err,
-				)
-			}
-			desire[i].NetworkVolume = int32(v)
-		}
-		if policyType, ok := annotations[ServiceAnnotationLoadBalancerPolicyType]; ok {
-			desire[i].PolicyType = policyType
-		}
-
-		if port.Protocol != v1.ProtocolTCP {
-			return nil, fmt.Errorf("only TCP load balancer is supported")
-		}
-		if port.NodePort == 0 {
-			klog.Errorf("Ignoring port without NodePort defined: %v", port)
-			continue
-		}
-
-		desire[i].LoadBalancerPort = int32(port.Port)
-		desire[i].InstancePort = int32(port.NodePort)
-
-		// health check
-		if strInterval, ok := annotations[ServiceAnnotationLoadBalancerHCInterval]; ok {
-			interval, err := strconv.Atoi(strInterval)
-			if err != nil {
-				return nil, fmt.Errorf(
-					"health check interval %q is invalid for service %q: %v",
-					strInterval, service.GetName(), err,
-				)
-			}
-			desire[i].HealthCheckInterval = int32(interval)
-		} else {
-			desire[i].HealthCheckInterval = defaultHealthCheckInterval
-		}
-
-		if unhealthyThreshold, ok := annotations[ServiceAnnotationLoadBalancerHCUnhealthyThreshold]; ok {
-			t, err := strconv.Atoi(unhealthyThreshold)
-			if err != nil {
-				return nil, fmt.Errorf(
-					"unhealthy threshold %q is invalid for service %q: %v",
-					unhealthyThreshold, service.GetName(), err,
-				)
-			}
-			desire[i].HealthCheckUnhealthyThreshold = int32(t)
-		} else {
-			desire[i].HealthCheckUnhealthyThreshold = defaultHealthCheckUnhealthyThreshold
-		}
-
-		if proto, ok := annotations[ServiceAnnotationLoadBalancerHCProtocol]; ok {
-			switch strings.ToUpper(proto) {
-			case "TCP":
-				desire[i].HealthCheckTarget = fmt.Sprintf("TCP:%d", port.NodePort)
-			case "ICMP":
-				desire[i].HealthCheckTarget = "ICMP"
-			default:
-				return nil, fmt.Errorf(
-					"health check protocol %q is invalid for service %q",
-					proto, service.GetName(),
-				)
-			}
-		} else {
-			desire[i].HealthCheckTarget = fmt.Sprintf("%s:%d", defaultHealthCheckTarget, port.NodePort)
-		}
-
-		// balancing targets
-		desire[i].BalancingTargets = instances
-
-		// filter
-		sourceRanges, err := servicehelpers.GetLoadBalancerSourceRanges(service)
+	if isElasticLoadBalancer(service.Annotations) {
+		elb, err := NewElasticLoadBalancerFromService(loadBalancerName, instances, service)
 		if err != nil {
 			return nil, err
 		}
-		filters := []string{}
-		if !servicehelpers.IsAllowAll(sourceRanges) {
-			for cidr := range sourceRanges {
-				if strings.HasSuffix(cidr, "/32") {
-					filters = append(filters, strings.TrimSuffix(cidr, "/32"))
-				} else {
-					filters = append(filters, strings.Replace(cidr, "/32", "", 1))
+		return c.ensureElasticLoadBalancer(ctx, loadBalancerName, elb)
+	} else {
+		desire := make([]LoadBalancer, portCount)
+		for i, port := range service.Spec.Ports {
+			// basic load balancer options
+			desire[i].Name = loadBalancerName
+			annotations := service.Annotations
+			if rawBalancingType, ok := annotations[ServiceAnnotationLoadBalancerBalancingType]; ok {
+				balancingType, err := strconv.Atoi(rawBalancingType)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"balancing type %q is invalid for service %q: %v",
+						rawBalancingType, service.GetName(), err,
+					)
+				}
+				desire[i].BalancingType = int32(balancingType)
+			}
+
+			if accountingType, ok := annotations[ServiceAnnotationLoadBalancerAccountingType]; ok {
+				desire[i].AccountingType = accountingType
+			}
+
+			if networkVolume, ok := annotations[ServiceAnnotationLoadBalancerNetworkVolume]; ok {
+				v, err := strconv.Atoi(networkVolume)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"network volume %q is invalid for service %q: %v",
+						networkVolume, service.GetName(), err,
+					)
+				}
+				desire[i].NetworkVolume = int32(v)
+			}
+			if policyType, ok := annotations[ServiceAnnotationLoadBalancerPolicyType]; ok {
+				desire[i].PolicyType = policyType
+			}
+
+			if port.Protocol != v1.ProtocolTCP {
+				return nil, fmt.Errorf("only TCP load balancer is supported")
+			}
+			if port.NodePort == 0 {
+				klog.Errorf("Ignoring port without NodePort defined: %v", port)
+				continue
+			}
+
+			desire[i].LoadBalancerPort = int32(port.Port)
+			desire[i].InstancePort = int32(port.NodePort)
+
+			// health check
+			if strInterval, ok := annotations[ServiceAnnotationLoadBalancerHCInterval]; ok {
+				interval, err := strconv.Atoi(strInterval)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"health check interval %q is invalid for service %q: %v",
+						strInterval, service.GetName(), err,
+					)
+				}
+				desire[i].HealthCheckInterval = int32(interval)
+			} else {
+				desire[i].HealthCheckInterval = defaultHealthCheckInterval
+			}
+
+			if unhealthyThreshold, ok := annotations[ServiceAnnotationLoadBalancerHCUnhealthyThreshold]; ok {
+				t, err := strconv.Atoi(unhealthyThreshold)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"unhealthy threshold %q is invalid for service %q: %v",
+						unhealthyThreshold, service.GetName(), err,
+					)
+				}
+				desire[i].HealthCheckUnhealthyThreshold = int32(t)
+			} else {
+				desire[i].HealthCheckUnhealthyThreshold = defaultHealthCheckUnhealthyThreshold
+			}
+
+			if proto, ok := annotations[ServiceAnnotationLoadBalancerHCProtocol]; ok {
+				switch strings.ToUpper(proto) {
+				case "TCP":
+					desire[i].HealthCheckTarget = fmt.Sprintf("TCP:%d", port.NodePort)
+				case "ICMP":
+					desire[i].HealthCheckTarget = "ICMP"
+				default:
+					return nil, fmt.Errorf(
+						"health check protocol %q is invalid for service %q",
+						proto, service.GetName(),
+					)
+				}
+			} else {
+				desire[i].HealthCheckTarget = fmt.Sprintf("%s:%d", defaultHealthCheckTarget, port.NodePort)
+			}
+
+			// balancing targets
+			desire[i].BalancingTargets = instances
+
+			// filter
+			sourceRanges, err := servicehelpers.GetLoadBalancerSourceRanges(service)
+			if err != nil {
+				return nil, err
+			}
+			filters := []string{}
+			if !servicehelpers.IsAllowAll(sourceRanges) {
+				for cidr := range sourceRanges {
+					if strings.HasSuffix(cidr, "/32") {
+						filters = append(filters, strings.TrimSuffix(cidr, "/32"))
+					} else {
+						filters = append(filters, strings.Replace(cidr, "/32", "", 1))
+					}
 				}
 			}
+			desire[i].Filters = sort.StringSlice(filters)
 		}
-		desire[i].Filters = sort.StringSlice(filters)
+		return c.ensureLoadBalancer(ctx, desire)
 	}
-
-	return c.ensureLoadBalancer(ctx, desire)
 }
 
 // UpdateLoadBalancer updates hosts under the specified load balancer
 func (c *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) error {
+	if isElasticLoadBalancer(service.Annotations) {
+		return c.updateElasticLoadBalancer(ctx, clusterName, service, nodes)
+	}
+
 	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
 
 	loadBalancers, err := c.client.DescribeLoadBalancers(ctx, loadBalancerName)
@@ -233,6 +277,10 @@ func (c *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, serv
 
 // EnsureLoadBalancerDeleted deletes the specified load balancer if it exists
 func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {
+	if isElasticLoadBalancer(service.Annotations) {
+		return c.ensureElasticLoadBalancerDeleted(ctx, clusterName, service)
+	}
+
 	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
 
 	loadBalancers, err := c.client.DescribeLoadBalancers(ctx, loadBalancerName)


### PR DESCRIPTION
## Summary

- Support  elastic load balancer
- Update nifcloud-sdk-go

## Review
- [ ] Check Result

## Result

### 1. Create elastic load balancer in one arm mode

```
$ cat test.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
        - name: nginx
          image: nginx:alpine
          ports:
            - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: nginx
  labels:
    app: nginx
  annotations:
    service.beta.kubernetes.io/nifcloud-load-balancer-type: elb
spec:
  type: LoadBalancer
  ports:
    - port: 80
      protocol: TCP
      targetPort: 80
  selector:
    app: nginx
$ kubectl apply -f test.yaml
```

- Elastic load balancer is created

![image](https://github.com/nifcloud/nifcloud-cloud-controller-manager/assets/28151082/4b472935-b6ab-4a53-9311-82f702d7fe54)

![image](https://github.com/nifcloud/nifcloud-cloud-controller-manager/assets/28151082/6fee69d3-3ba4-47c2-8d61-f4bf410018f2)

- Security group rules are created

![image](https://github.com/nifcloud/nifcloud-cloud-controller-manager/assets/28151082/df63f70f-8b18-4163-8b3b-155b1630ffcf)

- Log output

```
$ kubectl -n kube-system logs daemonset.apps/nifcloud-cloud-controller-manager
I0118 07:19:39.552086       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
I0118 07:19:49.926643       1 nifcloud_elastic_load_balancer.go:66] Creating ElasticLoadBalancer "bf9481bb405f4f2" (80 -> 32249)
I0118 07:25:12.133763       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuredLoadBalancer" message="Ensured load balancer"
```

2. Add a port to an existing load balancer

```
$ cat test2.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
        - name: nginx
          image: nginx:alpine
          ports:
            - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: nginx
  labels:
    app: nginx
  annotations:
    service.beta.kubernetes.io/nifcloud-load-balancer-type: elb
spec:
  type: LoadBalancer
  ports:
    - name: http
      port: 80
      protocol: TCP
      targetPort: 80
    - name: http2
      port: 8080
      protocol: TCP
      targetPort: 80
  selector:
    app: nginx
$ kubectl apply -f test2.yaml
```

- Elastic load balancer port is created

![image](https://github.com/nifcloud/nifcloud-cloud-controller-manager/assets/28151082/72e626bd-e85e-455f-bd80-84c5b9eb28ac)

- Security group rules are created

![image](https://github.com/nifcloud/nifcloud-cloud-controller-manager/assets/28151082/d323489d-d22f-481d-aa59-9f29cffd4b79)

- Log output

```
$ kubectl -n kube-system logs daemonset.apps/nifcloud-cloud-controller-manager
I0118 07:46:51.479391       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
I0118 07:46:53.671844       1 nifcloud_elastic_load_balancer.go:108] Registering ElasticLoadBalancer port "bf9481bb405f4f2" (8080 -> 30525)
I0118 07:49:13.743839       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuredLoadBalancer" message="Ensured load balancer"
```

3. Delete elastic load balancer

```
$ kubectl delete -f test2.yaml
```

- Log output

```
$ kubectl -n kube-system logs daemonset.apps/nifcloud-cloud-controller-manager
I0118 08:01:27.776096       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="DeletingLoadBalancer" message="Deleting load balancer"
I0118 08:01:28.383536       1 nifcloud_elastic_load_balancer.go:631] Deleting LoadBalancer "bf9481bb405f4f2" (80 -> 32249)
I0118 08:02:37.767129       1 nifcloud_elastic_load_balancer.go:631] Deleting LoadBalancer "bf9481bb405f4f2" (8080 -> 30525)
I0118 08:03:47.884602       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="DeletedLoadBalancer" message="Deleted load balancer"
```

- Elastic load balancers and security group rules created at 1. and 2. are deleted

4. Create elastic load balancer in two arm mode

```
$ cat test3.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
        - name: nginx
          image: nginx:alpine
          ports:
            - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: nginx
  labels:
    app: nginx
  annotations:
    service.beta.kubernetes.io/nifcloud-load-balancer-type: elb
    service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-1: net-COMMON_GLOBAL
    service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-2: <private-network-id>
    service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-2-ip-address: 192.168.2.149
    service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-2-system-ip-address-1: 192.168.2.150
    service.beta.kubernetes.io/nifcloud-load-balancer-network-interface-2-system-ip-address-2: 192.168.2.151
    service.beta.kubernetes.io/nifcloud-load-balancer-vip-network: "1"
spec:
  type: LoadBalancer
  ports:
    - port: 80
      protocol: TCP
      targetPort: 80
  selector:
    app: nginx
$ kubectl apply -f test3.yaml
```
- Elastic load balancer is created

![image](https://github.com/nifcloud/nifcloud-cloud-controller-manager/assets/28151082/10fde0d0-c709-4b1f-82ba-739c04f0261f)

- Security group rules are created

![image](https://github.com/nifcloud/nifcloud-cloud-controller-manager/assets/28151082/5a805ac5-ae66-4e4b-8fcd-913ca8b0ec99)

- Log output

```
$ kubectl -n kube-system logs daemonset.apps/nifcloud-cloud-controller-manager
I0119 02:21:49.799116       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
I0119 02:21:54.270889       1 nifcloud_elastic_load_balancer.go:66] Creating ElasticLoadBalancer "ff42801fc1d9495" (80 -> 31864)
I0119 02:27:38.215040       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuredLoadBalancer" message="Ensured load balancer"
```


