### PR TITLE
Add nifcloud error code for error handling

### DIFF
--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_client.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_client.go
@@ -261,7 +261,7 @@ func (c *nifcloudAPIClient) DescribeLoadBalancers(ctx context.Context, name stri
 	}
 	res, err := c.client.DescribeLoadBalancers(ctx, input)
 	if err != nil {
-		return nil, fmt.Errorf("could not fetch load balancers info for %q: %v", name, err)
+		return nil, fmt.Errorf("could not fetch load balancers info for %q: %w", name, err)
 	}
 
 	result := []LoadBalancer{}
@@ -559,7 +559,7 @@ func (c *nifcloudAPIClient) DescribeElasticLoadBalancers(ctx context.Context, na
 	}
 	res, err := c.client.NiftyDescribeElasticLoadBalancers(ctx, input)
 	if err != nil {
-		return nil, fmt.Errorf("could not fetch load balancers info for %q: %v", name, err)
+		return nil, fmt.Errorf("could not fetch load balancers info for %q: %w", name, err)
 	}
 
 	result := []ElasticLoadBalancer{}

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_client.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_client.go
@@ -216,6 +216,9 @@ func (c *nifcloudAPIClient) DescribeInstancesByInstanceID(ctx context.Context, i
 func (c *nifcloudAPIClient) DescribeInstancesByInstanceUniqueID(ctx context.Context, instanceUniqueIDs []string) ([]Instance, error) {
 	res, err := c.client.DescribeInstances(ctx, nil)
 	if err != nil {
+		if isAPIError(err, errorCodeInstanceNotFound) {
+			return nil, cloudprovider.InstanceNotFound
+		}
 		return nil, fmt.Errorf("failed to call DescribeInstances API: %w", err)
 	}
 

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
@@ -195,7 +195,7 @@ func NewElasticLoadBalancerFromService(loadBalancerName string, instances []Inst
 		balancingType, err := strconv.Atoi(rawBalancingType)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"balancing type %q is invalid for service %q: %v",
+				"balancing type %q is invalid for service %q: %w",
 				rawBalancingType, service.GetName(), err,
 			)
 		}
@@ -252,7 +252,7 @@ func NewElasticLoadBalancerFromService(loadBalancerName string, instances []Inst
 		interval, err := strconv.Atoi(strInterval)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"health check interval %q is invalid for service %q: %v",
+				"health check interval %q is invalid for service %q: %w",
 				strInterval, service.GetName(), err,
 			)
 		}
@@ -270,7 +270,7 @@ func NewElasticLoadBalancerFromService(loadBalancerName string, instances []Inst
 		t, err := strconv.Atoi(unhealthyThreshold)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unhealthy threshold %q is invalid for service %q: %v",
+				"unhealthy threshold %q is invalid for service %q: %w",
 				unhealthyThreshold, service.GetName(), err,
 			)
 		}

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_error_code.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_error_code.go
@@ -1,0 +1,30 @@
+package nifcloud
+
+import (
+	goerrors "errors"
+
+	"github.com/aws/smithy-go"
+)
+
+const (
+	// Instance
+	errorCodeInstanceNotFound = "Client.InvalidParameterNotFound.Instance"
+
+	// LoadBalancer
+	errorCodeLoadBalancerNotFound = "Client.InvalidParameterNotFound.LoadBalancer"
+
+	// ElasticLoadBalancer
+	errorCodeElasticLoadBalancerNotFound = "Client.InvalidParameterNotFound.ElasticLoadBalancer"
+
+	// SecurityGroup
+	errorCodeSecurityGroupIngressNotFound = "Client.InvalidParameterNotFound.SecurityGroupIngress"
+	errorCodeSecurityGroupDuplicate       = "Client.InvalidParameterDuplicate.SecurityGroup"
+)
+
+func isAPIError(err error, code string) bool {
+	var awsErr smithy.APIError
+	if goerrors.As(err, &awsErr) {
+		return awsErr.ErrorCode() == code
+	}
+	return false
+}

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_instances.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_instances.go
@@ -32,7 +32,7 @@ func (c *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.No
 func (c *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
 	instanceUniqueID, err := getInstanceUniqueIDFromProviderID(providerID)
 	if err != nil {
-		return nil, fmt.Errorf("unable to convert provider id %q: %v", providerID, err)
+		return nil, fmt.Errorf("unable to convert provider id %q: %w", providerID, err)
 	}
 
 	instances, err := c.client.DescribeInstancesByInstanceUniqueID(ctx, []string{instanceUniqueID})
@@ -85,7 +85,7 @@ func (c *Cloud) InstanceType(ctx context.Context, name types.NodeName) (string, 
 func (c *Cloud) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
 	instanceUniqueID, err := getInstanceUniqueIDFromProviderID(providerID)
 	if err != nil {
-		return "", fmt.Errorf("unable to convert provider id %q: %v", providerID, err)
+		return "", fmt.Errorf("unable to convert provider id %q: %w", providerID, err)
 	}
 
 	instances, err := c.client.DescribeInstancesByInstanceUniqueID(ctx, []string{instanceUniqueID})
@@ -115,7 +115,7 @@ func (c *Cloud) CurrentNodeName(ctx context.Context, hostname string) (types.Nod
 func (c *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
 	instanceUniqueID, err := getInstanceUniqueIDFromProviderID(providerID)
 	if err != nil {
-		return false, fmt.Errorf("unable to convert provider id %q: %v", providerID, err)
+		return false, fmt.Errorf("unable to convert provider id %q: %w", providerID, err)
 	}
 
 	instances, err := c.client.DescribeInstancesByInstanceUniqueID(ctx, []string{instanceUniqueID})

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_l4_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_l4_load_balancer.go
@@ -169,7 +169,7 @@ func NewL4LoadBalancerFromService(loadBalancerName string, instances []Instance,
 			balancingType, err := strconv.Atoi(rawBalancingType)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"balancing type %q is invalid for service %q: %v",
+					"balancing type %q is invalid for service %q: %w",
 					rawBalancingType, service.GetName(), err,
 				)
 			}
@@ -184,7 +184,7 @@ func NewL4LoadBalancerFromService(loadBalancerName string, instances []Instance,
 			v, err := strconv.Atoi(networkVolume)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"network volume %q is invalid for service %q: %v",
+					"network volume %q is invalid for service %q: %w",
 					networkVolume, service.GetName(), err,
 				)
 			}
@@ -210,7 +210,7 @@ func NewL4LoadBalancerFromService(loadBalancerName string, instances []Instance,
 			interval, err := strconv.Atoi(strInterval)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"health check interval %q is invalid for service %q: %v",
+					"health check interval %q is invalid for service %q: %w",
 					strInterval, service.GetName(), err,
 				)
 			}
@@ -223,7 +223,7 @@ func NewL4LoadBalancerFromService(loadBalancerName string, instances []Instance,
 			t, err := strconv.Atoi(unhealthyThreshold)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"unhealthy threshold %q is invalid for service %q: %v",
+					"unhealthy threshold %q is invalid for service %q: %w",
 					unhealthyThreshold, service.GetName(), err,
 				)
 			}

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
@@ -115,7 +115,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, serv
 	}
 	instances, err := c.client.DescribeInstancesByInstanceID(ctx, instanceIDs)
 	if err != nil {
-		return nil, fmt.Errorf("could not fetch instances info for %v: %v", instanceIDs, err)
+		return nil, fmt.Errorf("could not fetch instances info for %v: %w", instanceIDs, err)
 	}
 
 	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_zones.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_zones.go
@@ -35,7 +35,7 @@ func (c *Cloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 func (c *Cloud) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
 	instanceUniqueID, err := getInstanceUniqueIDFromProviderID(providerID)
 	if err != nil {
-		return cloudprovider.Zone{}, fmt.Errorf("unable to convert provider id %q: %v", providerID, err)
+		return cloudprovider.Zone{}, fmt.Errorf("unable to convert provider id %q: %w", providerID, err)
 	}
 
 	instances, err := c.client.DescribeInstancesByInstanceUniqueID(ctx, []string{instanceUniqueID})

--- a/pkg/cloudprovider/providers/nifcloud/util.go
+++ b/pkg/cloudprovider/providers/nifcloud/util.go
@@ -26,7 +26,7 @@ func getInstanceUniqueIDFromProviderID(providerID string) (string, error) {
 	}
 	url, err := url.Parse(s)
 	if err != nil {
-		return "", fmt.Errorf("Invalid instance name (%s): %v", providerID, err)
+		return "", fmt.Errorf("Invalid instance name (%s): %w", providerID, err)
 	}
 	if url.Scheme != "nifcloud" {
 		return "", fmt.Errorf("Invalid scheme for NIFCLOUD instance (%s)", providerID)


### PR DESCRIPTION
## Summary

- Add error code of nifcloud computing API
- Add some error handlings
- When a load balancer is not exisit, GetLoadBalancer return err=nil, exists=false.
- When a load balancer is not found, EnsureLoadBalancerDeleted return nil

## Review

- [x] Check Result

## Result

### Delete elastic load balancer already deleted.

```
$ cat test.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
        - name: nginx
          image: nginx:alpine
          ports:
            - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: nginx
  labels:
    app: nginx
  annotations:
    service.beta.kubernetes.io/nifcloud-load-balancer-type: elb
spec:
  type: LoadBalancer
  ports:
    - port: 80
      protocol: TCP
      targetPort: 80
  selector:
    app: nginx
$ kubectl apply -f test.yaml
# manually delete elasic load balancer
$ kubectl delete -f test.yaml
```

- Log output

```
I0418 02:44:40.999719       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
I0418 02:44:50.045163       1 nifcloud_elastic_load_balancer.go:66] Creating ElasticLoadBalancer "fc7bcf4c92b845f" (80 -> 32179)
I0418 02:49:20.479914       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuredLoadBalancer" message="Ensured load balancer"
I0418 03:00:14.283888       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="DeletedLoadBalancer" message="Deleted load balancer"
```

### Add port to elastic load balancer that deosn't exisit

```
$ kubectl apply -f test.yaml
# manually delete elasic load balancer
$ cat test2.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
        - name: nginx
          image: nginx:alpine
          ports:
            - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: nginx
  labels:
    app: nginx
  annotations:
    service.beta.kubernetes.io/nifcloud-load-balancer-type: elb
spec:
  type: LoadBalancer
  ports:
    - name: http
      port: 80
      protocol: TCP
      targetPort: 80
    - name: http2
      port: 8080
      protocol: TCP
      targetPort: 80
  selector:
    app: nginx
$ kubectl apply -f test2.yaml
```

- Log output

```
I0418 06:36:49.457835       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
I0418 06:36:54.995496       1 nifcloud_elastic_load_balancer.go:66] Creating ElasticLoadBalancer "b4df79ae138340d" (80 -> 31004)
I0418 06:41:33.616144       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuredLoadBalancer" message="Ensured load balancer"
I0418 07:05:27.264640       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
I0418 07:05:35.346895       1 nifcloud_elastic_load_balancer.go:66] Creating ElasticLoadBalancer "b4df79ae138340d" (80 -> 31004)
I0418 07:10:09.104229       1 nifcloud_elastic_load_balancer.go:66] Creating ElasticLoadBalancer "b4df79ae138340d" (8080 -> 30766)
I0418 07:12:35.141307       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuredLoadBalancer" message="Ensured load balancer"
```

###  Delete l4 load balancer already deleted.

```
$ cat testlb.yaml 
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
        - name: nginx
          image: nginx:alpine
          ports:
            - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: nginx
  labels:
    app: nginx
  annotations:
    service.beta.kubernetes.io/nifcloud-load-balancer-type: lb
spec:
  type: LoadBalancer
  ports:
    - port: 80
      protocol: TCP
      targetPort: 80
  selector:
    app: nginx
$ kubectl apply -f testlb.yaml
# manually delete l4 load balancer
$ kubectl delete -f testlb.yaml
```

```
I0418 07:32:36.551429       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
I0418 07:32:43.943110       1 nifcloud_l4_load_balancer.go:52] Creating LoadBalancer "dbc8d4b73b8b45d" (80 -> 31662)
I0418 07:33:05.768225       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuredLoadBalancer" message="Ensured load balancer"
I0418 07:39:25.947828       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="DeletedLoadBalancer" message="Deleted load balancer"
```

### Add port to l4 load balancer that deosn't exisit

```
$ kubectl apply -f testlb.yaml
# manually delete l4 load balancer
$ cat testlb2.yaml 
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
        - name: nginx
          image: nginx:alpine
          ports:
            - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: nginx
  labels:
    app: nginx
  annotations:
    service.beta.kubernetes.io/nifcloud-load-balancer-type: lb
spec:
  type: LoadBalancer
  ports:
    - name: http
      port: 80
      protocol: TCP
      targetPort: 80
    - name: http2
      port: 8080
      protocol: TCP
      targetPort: 80
  selector:
    app: nginx
$ kubectl apply -f testlb2.yaml
```

```
I0418 07:46:34.676061       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
I0418 07:46:38.817353       1 nifcloud_l4_load_balancer.go:52] Creating LoadBalancer "89a7e6450320404" (80 -> 31066)
I0418 07:47:03.813998       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuredLoadBalancer" message="Ensured load balancer"
I0418 08:14:03.683586       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
I0418 08:14:15.309943       1 nifcloud_l4_load_balancer.go:52] Creating LoadBalancer "89a7e6450320404" (80 -> 31066)
I0418 08:14:34.088389       1 nifcloud_l4_load_balancer.go:52] Creating LoadBalancer "89a7e6450320404" (8080 -> 32011)
I0418 08:14:44.870552       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuredLoadBalancer" message="Ensured load balancer"
```