### PR TITLE
Add validation for annotations

### DIFF
--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_elastic_load_balancer.go
@@ -47,7 +47,6 @@ func (c *Cloud) getElasticLoadBalancer(ctx context.Context, clusterName string, 
 }
 
 func (c *Cloud) ensureElasticLoadBalancer(ctx context.Context, loadBalancerName string, desire []ElasticLoadBalancer) (*v1.LoadBalancerStatus, error) {
-	// TODO: Add Validation
 	// correct state differences
 	if len(desire) == 0 {
 		return nil, fmt.Errorf("desire ElasticLoadBalancer length must be larger than 1")
@@ -173,7 +172,6 @@ func (c *Cloud) ensureElasticLoadBalancer(ctx context.Context, loadBalancerName 
 }
 
 func NewElasticLoadBalancerFromService(loadBalancerName string, instances []Instance, service *v1.Service) ([]ElasticLoadBalancer, error) {
-	// TODO: validation
 	portCount := len(service.Spec.Ports)
 
 	// detect state differences

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
@@ -200,6 +200,12 @@ func validateLoadBalancerAnnotations(annotations map[string]string) error {
 		}
 	}
 
+	if proto, ok := annotations[ServiceAnnotationLoadBalancerHCProtocol]; ok {
+		if proto != "TCP" && proto != "ICMP" {
+			return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerHCProtocol, proto)
+		}
+	}
+
 	if unhealthyThreshold, ok := annotations[ServiceAnnotationLoadBalancerHCUnhealthyThreshold]; ok {
 		t, err := strconv.Atoi(unhealthyThreshold)
 		if err != nil || t < 1 || 10 < t {
@@ -225,12 +231,6 @@ func validateLoadBalancerAnnotations(annotations map[string]string) error {
 		if policyType, ok := annotations[ServiceAnnotationLoadBalancerPolicyType]; ok {
 			if policyType != "standard" && policyType != "ats" {
 				return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerPolicyType, policyType)
-			}
-		}
-
-		if proto, ok := annotations[ServiceAnnotationLoadBalancerHCProtocol]; ok {
-			if proto != "TCP" && proto != "ICMP" {
-				return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerHCProtocol, proto)
 			}
 		}
 
@@ -287,12 +287,6 @@ func validateLoadBalancerAnnotations(annotations map[string]string) error {
 		if policyType, ok := annotations[ServiceAnnotationLoadBalancerPolicyType]; ok {
 			if policyType != "" {
 				return fmt.Errorf("annotation %s is only enabled for %s=lb", ServiceAnnotationLoadBalancerPolicyType, ServiceAnnotationLoadBalancerType)
-			}
-		}
-
-		if proto, ok := annotations[ServiceAnnotationLoadBalancerHCProtocol]; ok {
-			if proto != "TCP" && proto != "ICMP" {
-				return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerHCProtocol, proto)
 			}
 		}
 

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
@@ -297,7 +297,7 @@ func validateLoadBalancerAnnotations(annotations map[string]string) error {
 						return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerNetworkInterface1IPAddress, ipAddress)
 					}
 				} else {
-					return fmt.Errorf("annotation %s is required when %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface1IPAddress, ServiceAnnotationLoadBalancerNetworkInterface1)
+					return fmt.Errorf("annotation %s is required when %s is private lan", ServiceAnnotationLoadBalancerNetworkInterface1IPAddress, ServiceAnnotationLoadBalancerNetworkInterface1)
 				}
 
 				if systemIPAddresses, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses]; ok {
@@ -311,18 +311,18 @@ func validateLoadBalancerAnnotations(annotations map[string]string) error {
 						}
 					}
 				} else {
-					return fmt.Errorf("annotation %s is required when %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses, ServiceAnnotationLoadBalancerNetworkInterface1)
+					return fmt.Errorf("annotation %s is required when %s is private lan", ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses, ServiceAnnotationLoadBalancerNetworkInterface1)
 				}
 			} else {
 				if ipAddress, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1IPAddress]; ok {
 					if ipAddress != "" {
-						return fmt.Errorf("can set %s only %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface1IPAddress, ServiceAnnotationLoadBalancerNetworkInterface1)
+						return fmt.Errorf("can set %s only %s is private lan", ServiceAnnotationLoadBalancerNetworkInterface1IPAddress, ServiceAnnotationLoadBalancerNetworkInterface1)
 					}
 				}
 
 				if systemIPAddresses, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses]; ok {
 					if systemIPAddresses != "" {
-						return fmt.Errorf("can set %s only %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses, ServiceAnnotationLoadBalancerNetworkInterface1)
+						return fmt.Errorf("can set %s only %s is private lan", ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses, ServiceAnnotationLoadBalancerNetworkInterface1)
 					}
 				}
 			}
@@ -335,7 +335,7 @@ func validateLoadBalancerAnnotations(annotations map[string]string) error {
 						return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerNetworkInterface2IPAddress, ipAddress)
 					}
 				} else {
-					return fmt.Errorf("%s is required when %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface2IPAddress, ServiceAnnotationLoadBalancerNetworkInterface2)
+					return fmt.Errorf("%s is required when %s is private lan", ServiceAnnotationLoadBalancerNetworkInterface2IPAddress, ServiceAnnotationLoadBalancerNetworkInterface2)
 				}
 
 				if systemIPAddresses, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses]; ok {
@@ -349,18 +349,18 @@ func validateLoadBalancerAnnotations(annotations map[string]string) error {
 						}
 					}
 				} else {
-					return fmt.Errorf("annotation %s is required when %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses, ServiceAnnotationLoadBalancerNetworkInterface1)
+					return fmt.Errorf("annotation %s is required when %s is private lan", ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses, ServiceAnnotationLoadBalancerNetworkInterface1)
 				}
 			} else {
 				if ipAddress, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2IPAddress]; ok {
 					if ipAddress != "" {
-						return fmt.Errorf("can set %s only %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface2IPAddress, ServiceAnnotationLoadBalancerNetworkInterface2)
+						return fmt.Errorf("can set %s only %s is private lan", ServiceAnnotationLoadBalancerNetworkInterface2IPAddress, ServiceAnnotationLoadBalancerNetworkInterface2)
 					}
 				}
 
 				if systemIPAddresses, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses]; ok {
 					if systemIPAddresses != "" {
-						return fmt.Errorf("can set %s only %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses, ServiceAnnotationLoadBalancerNetworkInterface2)
+						return fmt.Errorf("can set %s only %s is private lan", ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses, ServiceAnnotationLoadBalancerNetworkInterface2)
 					}
 				}
 			}

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_load_balancer.go
@@ -3,8 +3,10 @@ package nifcloud
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
+	"golang.org/x/exp/slices"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -46,7 +48,7 @@ const (
 	// See https://pfs.nifcloud.com/api/rest/ConfigureHealthCheck.htm
 	ServiceAnnotationLoadBalancerHCProtocol = "service.beta.kubernetes.io/nifcloud-load-balancer-healthcheck-protocol"
 
-	// ServiceAnnotationLoadBalancerHCUnhealthyThreshold is the annotation that specify the number of unsuccessfull
+	// ServiceAnnotationLoadBalancerHCUnhealthyThreshold is the annotation that specify the number of unsuccessful
 	// health checks count required for a backend to be considered unhealthy for traffic
 	// See https://pfs.nifcloud.com/api/rest/ConfigureHealthCheck.htm
 	ServiceAnnotationLoadBalancerHCUnhealthyThreshold = "service.beta.kubernetes.io/nifcloud-load-balancer-healthcheck-unhealthy-threshold"
@@ -79,6 +81,12 @@ const (
 	ServiceAnnotationLoadBalancerVipNetwork = "service.beta.kubernetes.io/nifcloud-load-balancer-vip-network"
 )
 
+var allowedElasticLoadBalancerNetworkVolume = []string{"10", "20", "30", "40", "100", "200", "300", "400", "500"}
+var allowedL4LoadBalancerNetworkVolume = []string{
+	"10", "20", "30", "40", "100", "200", "300", "400", "500", "600", "700", "800", "900", "1000",
+	"1100", "1200", "1300", "1400", "1500", "1600", "1700", "1800", "1900", "2000",
+}
+
 // GetLoadBalancer returns whether the specified load balancer exists, and if so, what its status is
 func (c *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {
 	if isElasticLoadBalancer(service.Annotations) {
@@ -87,7 +95,7 @@ func (c *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, service
 	if isL4LoadBalancer(service.Annotations) {
 		return c.getL4LoadBalancer(ctx, clusterName, service)
 	}
-	return nil, false, fmt.Errorf("the load balancer type is not supported")
+	return nil, false, nil
 }
 
 // GetLoadBalancerName returns the name of the load balancer
@@ -120,6 +128,11 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, serv
 
 	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
 
+	err = validateLoadBalancerAnnotations(service.Annotations)
+	if err != nil {
+		return nil, err
+	}
+
 	if isElasticLoadBalancer(service.Annotations) {
 		elb, err := NewElasticLoadBalancerFromService(loadBalancerName, instances, service)
 		if err != nil {
@@ -139,6 +152,11 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, serv
 
 // UpdateLoadBalancer updates hosts under the specified load balancer
 func (c *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) error {
+	err := validateLoadBalancerAnnotations(service.Annotations)
+	if err != nil {
+		return err
+	}
+
 	if isElasticLoadBalancer(service.Annotations) {
 		return c.updateElasticLoadBalancer(ctx, clusterName, service, nodes)
 	}
@@ -157,6 +175,211 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
 		return c.ensureL4LoadBalancerDeleted(ctx, clusterName, service)
 	}
 	return fmt.Errorf("the load balancer type is not supported")
+}
+
+func validateLoadBalancerAnnotations(annotations map[string]string) error {
+	// validation of both l4 load balancer and elastic load balancer
+	loadBalancerType, ok := annotations[ServiceAnnotationLoadBalancerType]
+	if ok {
+		if loadBalancerType != "lb" && loadBalancerType != "elb" {
+			return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerType, loadBalancerType)
+		}
+	} else {
+		loadBalancerType = "lb"
+	}
+
+	if balancingType, ok := annotations[ServiceAnnotationLoadBalancerBalancingType]; ok {
+		if balancingType != "1" && balancingType != "2" {
+			return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerBalancingType, balancingType)
+		}
+	}
+
+	if accountingType, ok := annotations[ServiceAnnotationLoadBalancerAccountingType]; ok {
+		if accountingType != "1" && accountingType != "2" {
+			return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerAccountingType, accountingType)
+		}
+	}
+
+	if unhealthyThreshold, ok := annotations[ServiceAnnotationLoadBalancerHCUnhealthyThreshold]; ok {
+		t, err := strconv.Atoi(unhealthyThreshold)
+		if err != nil || t < 1 || 10 < t {
+			return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerHCUnhealthyThreshold, unhealthyThreshold)
+		}
+	}
+
+	if healthCheckInterval, ok := annotations[ServiceAnnotationLoadBalancerHCInterval]; ok {
+		interval, err := strconv.Atoi(healthCheckInterval)
+		if err != nil || interval < 5 || 300 < interval {
+			return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerHCInterval, healthCheckInterval)
+		}
+	}
+
+	if loadBalancerType == "lb" {
+		// validation of l4 load balancer
+		if networkVolume, ok := annotations[ServiceAnnotationLoadBalancerNetworkVolume]; ok {
+			if !slices.Contains(allowedL4LoadBalancerNetworkVolume, networkVolume) {
+				return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerNetworkVolume, networkVolume)
+			}
+		}
+
+		if policyType, ok := annotations[ServiceAnnotationLoadBalancerPolicyType]; ok {
+			if policyType != "standard" && policyType != "ats" {
+				return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerPolicyType, policyType)
+			}
+		}
+
+		if proto, ok := annotations[ServiceAnnotationLoadBalancerHCProtocol]; ok {
+			if proto != "TCP" && proto != "ICMP" {
+				return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerHCProtocol, proto)
+			}
+		}
+
+		if networkInterface, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1]; ok {
+			if networkInterface != "" {
+				return fmt.Errorf("annotation %s is only enabled for %s=elb", ServiceAnnotationLoadBalancerNetworkInterface1, ServiceAnnotationLoadBalancerType)
+			}
+		}
+
+		if networkInterface, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2]; ok {
+			if networkInterface != "" {
+				return fmt.Errorf("annotation %s is only enabled for %s=elb", ServiceAnnotationLoadBalancerNetworkInterface2, ServiceAnnotationLoadBalancerType)
+			}
+		}
+
+		if ipAddress, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1IPAddress]; ok {
+			if ipAddress != "" {
+				return fmt.Errorf("annotation %s is only enabled for %s=elb", ServiceAnnotationLoadBalancerNetworkInterface1IPAddress, ServiceAnnotationLoadBalancerType)
+			}
+		}
+
+		if ipAddress, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2IPAddress]; ok {
+			if ipAddress != "" {
+				return fmt.Errorf("annotation %s is only enabled for %s=elb", ServiceAnnotationLoadBalancerNetworkInterface2IPAddress, ServiceAnnotationLoadBalancerType)
+			}
+		}
+
+		if systemIPAddresses, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses]; ok {
+			if systemIPAddresses != "" {
+				return fmt.Errorf("annotation %s is only enabled for %s=elb", ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses, ServiceAnnotationLoadBalancerType)
+			}
+		}
+
+		if systemIPAddresses, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses]; ok {
+			if systemIPAddresses != "" {
+				return fmt.Errorf("annotation %s is only enabled for %s=elb", ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses, ServiceAnnotationLoadBalancerType)
+			}
+		}
+
+		if vipNetwork, ok := annotations[ServiceAnnotationLoadBalancerVipNetwork]; ok {
+			if vipNetwork != "" {
+				return fmt.Errorf("annotation %s is only enabled for %s=elb", ServiceAnnotationLoadBalancerVipNetwork, ServiceAnnotationLoadBalancerType)
+			}
+		}
+	}
+	if loadBalancerType == "elb" {
+		// validation of elastic load balancer
+		if networkVolume, ok := annotations[ServiceAnnotationLoadBalancerNetworkVolume]; ok {
+			if !slices.Contains(allowedElasticLoadBalancerNetworkVolume, networkVolume) {
+				return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerNetworkVolume, networkVolume)
+			}
+		}
+
+		if policyType, ok := annotations[ServiceAnnotationLoadBalancerPolicyType]; ok {
+			if policyType != "" {
+				return fmt.Errorf("annotation %s is only enabled for %s=lb", ServiceAnnotationLoadBalancerPolicyType, ServiceAnnotationLoadBalancerType)
+			}
+		}
+
+		if proto, ok := annotations[ServiceAnnotationLoadBalancerHCProtocol]; ok {
+			if proto != "TCP" && proto != "ICMP" {
+				return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerHCProtocol, proto)
+			}
+		}
+
+		if networkInterface1, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1]; ok {
+			if isPrivateLanNetworkID(networkInterface1) {
+				if ipAddress, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1IPAddress]; ok {
+					if !isIPAddress(ipAddress) {
+						return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerNetworkInterface1IPAddress, ipAddress)
+					}
+				} else {
+					return fmt.Errorf("annotation %s is required when %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface1IPAddress, ServiceAnnotationLoadBalancerNetworkInterface1)
+				}
+
+				if systemIPAddresses, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses]; ok {
+					separatedSystemIPAdresses := strings.Split(systemIPAddresses, ",")
+					if len(separatedSystemIPAdresses) != 2 {
+						return fmt.Errorf("annotation %s is required two ip addresses", ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses)
+					}
+					for i := range separatedSystemIPAdresses {
+						if !isIPAddress(separatedSystemIPAdresses[i]) {
+							return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses, systemIPAddresses)
+						}
+					}
+				} else {
+					return fmt.Errorf("annotation %s is required when %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses, ServiceAnnotationLoadBalancerNetworkInterface1)
+				}
+			} else {
+				if ipAddress, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1IPAddress]; ok {
+					if ipAddress != "" {
+						return fmt.Errorf("can set %s only %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface1IPAddress, ServiceAnnotationLoadBalancerNetworkInterface1)
+					}
+				}
+
+				if systemIPAddresses, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses]; ok {
+					if systemIPAddresses != "" {
+						return fmt.Errorf("can set %s only %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface1SystemIPAddresses, ServiceAnnotationLoadBalancerNetworkInterface1)
+					}
+				}
+			}
+		}
+
+		if networkInterface2, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2]; ok {
+			if isPrivateLanNetworkID(networkInterface2) {
+				if ipAddress, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2IPAddress]; ok {
+					if !isIPAddress(ipAddress) {
+						return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerNetworkInterface2IPAddress, ipAddress)
+					}
+				} else {
+					return fmt.Errorf("%s is required when %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface2IPAddress, ServiceAnnotationLoadBalancerNetworkInterface2)
+				}
+
+				if systemIPAddresses, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses]; ok {
+					separatedSystemIPAdresses := strings.Split(systemIPAddresses, ",")
+					if len(separatedSystemIPAdresses) != 2 {
+						return fmt.Errorf("%s is required two ip addresses", ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses)
+					}
+					for i := range separatedSystemIPAdresses {
+						if !isIPAddress(separatedSystemIPAdresses[i]) {
+							return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses, systemIPAddresses)
+						}
+					}
+				} else {
+					return fmt.Errorf("annotation %s is required when %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses, ServiceAnnotationLoadBalancerNetworkInterface1)
+				}
+			} else {
+				if ipAddress, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2IPAddress]; ok {
+					if ipAddress != "" {
+						return fmt.Errorf("can set %s only %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface2IPAddress, ServiceAnnotationLoadBalancerNetworkInterface2)
+					}
+				}
+
+				if systemIPAddresses, ok := annotations[ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses]; ok {
+					if systemIPAddresses != "" {
+						return fmt.Errorf("can set %s only %s is private ip", ServiceAnnotationLoadBalancerNetworkInterface2SystemIPAddresses, ServiceAnnotationLoadBalancerNetworkInterface2)
+					}
+				}
+			}
+		}
+
+		if vipNetwork, ok := annotations[ServiceAnnotationLoadBalancerVipNetwork]; ok {
+			if vipNetwork != "1" && vipNetwork != "2" {
+				return fmt.Errorf("annotation %s=%s is invalid", ServiceAnnotationLoadBalancerVipNetwork, vipNetwork)
+			}
+		}
+	}
+
+	return nil
 }
 
 func toLoadBalancerStatus(vip string) *v1.LoadBalancerStatus {

--- a/pkg/cloudprovider/providers/nifcloud/util.go
+++ b/pkg/cloudprovider/providers/nifcloud/util.go
@@ -2,6 +2,7 @@ package nifcloud
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"os/exec"
 	"strings"
@@ -58,4 +59,8 @@ func isSingleInstance(instances []Instance, name string) error {
 	}
 
 	return nil
+}
+
+func isIPAddress(ipAddress string) bool {
+	return net.ParseIP(ipAddress) != nil
 }


### PR DESCRIPTION
## Summary

- Add validation for annotations

## Review

- [x] Check Result

## Result

### given annotations is invalid

- annotations

```yaml
annotations:
  service.beta.kubernetes.io/nifcloud-load-balancer-type: elb
  service.beta.kubernetes.io/nifcloud-load-balancer-balancing-type: "3" # only set "1" or "2"
```

- create resource

Run `kubectl apply -f test.yaml` and creating elb is failed.

```
[nifcloud-cloud-controller-manager-sl97g] I0425 02:08:38.175281       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Warning" reason="SyncLoadBalancerFailed" message="Error syncing load balancer: failed to ensure load balancer: annotation service.beta.kubernetes.io/nifcloud-load-balancer-balancing-type=3 is invalid"
[nifcloud-cloud-controller-manager-sl97g] I0425 02:08:43.176909       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
[nifcloud-cloud-controller-manager-sl97g] E0425 02:08:44.375115       1 controller.go:298] error processing service default/nginx (retrying with exponential backoff): failed to ensure load balancer: annotation service.beta.kubernetes.io/nifcloud-load-balancer-balancing-type=3 is invalid
[nifcloud-cloud-controller-manager-sl97g] I0425 02:08:44.375349       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Warning" reason="SyncLoadBalancerFailed" message="Error syncing load balancer: failed to ensure load balancer: annotation service.beta.kubernetes.io/nifcloud-load-balancer-balancing-type=3 is invalid"
```

- delete resource

Run `kubectl delete -f test.yaml` and deleteing resources is successs.

```
[nifcloud-cloud-controller-manager-sl97g] E0425 02:09:17.484413       1 controller.go:298] error processing service default/nginx (retrying with exponential backoff): failed to ensure load balancer: annotation service.beta.kubernetes.io/nifcloud-load-balancer-balancing-type=3 is invalid
[nifcloud-cloud-controller-manager-sl97g] I0425 02:09:17.484524       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Warning" reason="SyncLoadBalancerFailed" message="Error syncing load balancer: failed to ensure load balancer: annotation service.beta.kubernetes.io/nifcloud-load-balancer-balancing-type=3 is invalid"
[nifcloud-cloud-controller-manager-sl97g] I0425 02:09:33.438512       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="DeletedLoadBalancer" message="Deleted load balancer"
```

### given annotations is mismatch

- annotations

```yml
annotations:
  service.beta.kubernetes.io/nifcloud-load-balancer-type: elb
  service.beta.kubernetes.io/nifcloud-load-balancer-policy-type: standard # annotation for lb
```
- create resource

Run `kubectl apply -f test.yaml` and creating elb is failed.

```
[nifcloud-cloud-controller-manager-sl97g] I0425 02:49:00.041771       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
[nifcloud-cloud-controller-manager-sl97g] E0425 02:49:02.555024       1 controller.go:298] error processing service default/nginx (retrying with exponential backoff): failed to ensure load balancer: annotation service.beta.kubernetes.io/nifcloud-load-balancer-policy-type is only enabled for service.beta.kubernetes.io/nifcloud-load-balancer-type=lb
[nifcloud-cloud-controller-manager-sl97g] I0425 02:49:02.555098       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Warning" reason="SyncLoadBalancerFailed" message="Error syncing load balancer: failed to ensure load balancer: annotation service.beta.kubernetes.io/nifcloud-load-balancer-policy-type is only enabled for service.beta.kubernetes.io/nifcloud-load-balancer-type=lb"
```
- delete resource

Run `kubectl delete -f test.yaml` and deleteing resources is successs.

```
[nifcloud-cloud-controller-manager-sl97g] I0425 02:49:44.816450       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Warning" reason="SyncLoadBalancerFailed" message="Error syncing load balancer: failed to ensure load balancer: annotation service.beta.kubernetes.io/nifcloud-load-balancer-policy-type is only enabled for service.beta.kubernetes.io/nifcloud-load-balancer-type=lb"
[nifcloud-cloud-controller-manager-sl97g] I0425 02:49:54.643078       1 event.go:307] "Event occurred" object="default/nginx" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="DeletedLoadBalancer" message="Deleted load balancer"
```

