### PR TITLE
Add instances test

### DIFF
--- a/pkg/cloudprovider/providers/nifcloud/export_test.go
+++ b/pkg/cloudprovider/providers/nifcloud/export_test.go
@@ -12,6 +12,7 @@ func (c *Cloud) SetRegion(region string) {
 
 // nifcloud_instances.go
 var ExportGetInstance = (*Cloud).getInstance
+var ExportGetNodeAddress = getNodeAddress
 
 // nifcloud_load_balancer.go
 

--- a/pkg/cloudprovider/providers/nifcloud/export_test.go
+++ b/pkg/cloudprovider/providers/nifcloud/export_test.go
@@ -10,6 +10,9 @@ func (c *Cloud) SetRegion(region string) {
 	c.region = region
 }
 
+// nifcloud_instances.go
+var ExportGetInstance = (*Cloud).getInstance
+
 // nifcloud_load_balancer.go
 
 var ExportMaxLoadBalancerNameLength = maxLoadBalancerNameLength

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_instances.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_instances.go
@@ -2,6 +2,7 @@ package nifcloud
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -138,7 +139,7 @@ func (c *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID str
 func (c *Cloud) InstanceExists(ctx context.Context, node *v1.Node) (bool, error) {
 	_, err := c.getInstance(ctx, node)
 	if err != nil {
-		if isAPIError(err, errorCodeInstanceNotFound) {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			return false, nil
 		}
 		return false, err

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_instances.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_instances.go
@@ -2,7 +2,6 @@ package nifcloud
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 
@@ -139,7 +138,7 @@ func (c *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID str
 func (c *Cloud) InstanceExists(ctx context.Context, node *v1.Node) (bool, error) {
 	_, err := c.getInstance(ctx, node)
 	if err != nil {
-		if errors.Is(err, cloudprovider.InstanceNotFound) {
+		if isAPIError(err, errorCodeInstanceNotFound) {
 			return false, nil
 		}
 		return false, err

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
@@ -12,6 +12,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	cloudprovider "k8s.io/cloud-provider"
 )
 
 var _ = Describe("NodeAddresses", func() {
@@ -777,6 +778,121 @@ var _ = Describe("InstanceShutdown", func() {
 			stopped, err := cloud.InstanceShutdown(ctx, testNode)
 			Expect(err).Should(HaveOccurred())
 			Expect(stopped).Should(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("InstanceMetadata", func() {
+	var ctrl *gomock.Controller
+	var region string = "east1"
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("single instance is existed", func() {
+		It("return the metadata", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{*helper.NewTestInstance()}
+			testProviderID := "nifcloud:///east-11/i-abcd1234"
+			testInstanceUniqueID := "i-abcd1234"
+			testNode := &v1.Node{
+				Spec: v1.NodeSpec{
+					ProviderID: testProviderID,
+				},
+			}
+
+			expectedMetadata := &cloudprovider.InstanceMetadata{
+				ProviderID:   testProviderID,
+				InstanceType: testInstances[0].InstanceType,
+				NodeAddresses: []v1.NodeAddress{
+					{
+						Type:    v1.NodeExternalIP,
+						Address: testInstances[0].PublicIPAddress,
+					},
+					{
+						Type:    v1.NodeInternalIP,
+						Address: testInstances[0].PrivateIPAddress,
+					},
+				},
+				Zone:   testInstances[0].Zone,
+				Region: region,
+			}
+
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
+				Return(testInstances, nil).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			metadata, err := cloud.InstanceMetadata(ctx, testNode)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(metadata).Should(Equal(expectedMetadata))
+		})
+	})
+
+	Context("the instance is not existed", func() {
+		It("return error", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{}
+			testProviderID := "nifcloud:///east-11/i-abcd1234"
+			testInstanceUniqueID := "i-abcd1234"
+			testNode := &v1.Node{
+				Spec: v1.NodeSpec{
+					ProviderID: testProviderID,
+				},
+			}
+
+			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
+				Return(testInstances, notFoundErr).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			metadata, err := cloud.InstanceMetadata(ctx, testNode)
+			Expect(err).Should(HaveOccurred())
+			Expect(metadata).Should(BeNil())
+		})
+	})
+
+	Context("some instances have same InstanceID are existed", func() {
+		It("return error", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{*helper.NewTestInstance(), *helper.NewTestInstance()}
+			testProviderID := "nifcloud:///east-11/i-abcd1234"
+			testInstanceUniqueID := "i-abcd1234"
+			testNode := &v1.Node{
+				Spec: v1.NodeSpec{
+					ProviderID: testProviderID,
+				},
+			}
+
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
+				Return(testInstances, nil).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			metadata, err := cloud.InstanceMetadata(ctx, testNode)
+			Expect(err).Should(HaveOccurred())
+			Expect(metadata).Should(BeNil())
 		})
 	})
 })

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
@@ -103,3 +103,96 @@ var _ = Describe("NodeAddresses", func() {
 		})
 	})
 })
+
+var _ = Describe("NodeAddressesByProviderID", func() {
+	var ctrl *gomock.Controller
+	var region string = "east1"
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("single instance is existed", func() {
+		It("return the NodeAddress", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{*helper.NewTestInstance()}
+			testProviderID := "nifcloud:///east-11/i-abcd1234"
+			testInstanceUniqueID := "i-abcd1234"
+			expectedNodeAddress := []v1.NodeAddress{
+				{
+					Type:    v1.NodeExternalIP,
+					Address: testInstances[0].PublicIPAddress,
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: testInstances[0].PrivateIPAddress,
+				},
+			}
+
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
+				Return(testInstances, nil).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			nodeAddress, err := cloud.NodeAddressesByProviderID(ctx, testProviderID)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(nodeAddress).Should(Equal(expectedNodeAddress))
+		})
+	})
+
+	Context("the instance is not existed", func() {
+		It("return error", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{}
+			testProviderID := "nifcloud:///east-11/i-abcd1234"
+			testInstanceUniqueID := "i-abcd1234"
+
+			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
+				Return(testInstances, notFoundErr).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			nodeAddress, err := cloud.NodeAddressesByProviderID(ctx, testProviderID)
+			Expect(err).Should(HaveOccurred())
+			Expect(nodeAddress).Should(BeNil())
+		})
+	})
+
+	Context("some instances have same InstanceID are existed", func() {
+		It("return error", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{*helper.NewTestInstance(), *helper.NewTestInstance()}
+			testProviderID := "nifcloud:///east-11/i-abcd1234"
+			testInstanceUniqueID := "i-abcd1234"
+
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
+				Return(testInstances, nil).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			nodeAddress, err := cloud.NodeAddressesByProviderID(ctx, testProviderID)
+			Expect(err).Should(HaveOccurred())
+			Expect(nodeAddress).Should(BeNil())
+		})
+	})
+})

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
@@ -277,3 +277,83 @@ var _ = Describe("InstanceID", func() {
 		})
 	})
 })
+
+var _ = Describe("InstanceType", func() {
+	var ctrl *gomock.Controller
+	var region string = "east1"
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("single instance is existed", func() {
+		It("return the InstanceType", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{*helper.NewTestInstance()}
+			nodeName := testInstances[0].InstanceID
+
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceID(gomock.Any(), []string{nodeName}).
+				Return(testInstances, nil).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			gotInstanceType, err := cloud.InstanceType(ctx, types.NodeName(nodeName))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(gotInstanceType).Should(Equal(testInstances[0].InstanceType))
+		})
+	})
+
+	Context("the instance is not existed", func() {
+		It("return error", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{}
+			nodeName := "testinstance"
+
+			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceID(gomock.Any(), []string{nodeName}).
+				Return(testInstances, notFoundErr).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			gotInstanceType, err := cloud.InstanceType(ctx, types.NodeName(nodeName))
+			Expect(err).Should(HaveOccurred())
+			Expect(gotInstanceType).Should(BeEmpty())
+		})
+	})
+
+	Context("some instances have same InstanceID are existed", func() {
+		It("return error", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{*helper.NewTestInstance(), *helper.NewTestInstance()}
+			nodeName := testInstances[0].InstanceID
+
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceID(gomock.Any(), []string{nodeName}).
+				Return(testInstances, nil).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			gotInstanceType, err := cloud.InstanceType(ctx, types.NodeName(nodeName))
+			Expect(err).Should(HaveOccurred())
+			Expect(gotInstanceType).Should(BeEmpty())
+		})
+	})
+})

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
@@ -1,0 +1,105 @@
+package nifcloud_test
+
+import (
+	"context"
+
+	"github.com/nifcloud/nifcloud-cloud-controller-manager/pkg/cloudprovider/providers/nifcloud"
+	"github.com/nifcloud/nifcloud-cloud-controller-manager/test/helper"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("NodeAddresses", func() {
+	var ctrl *gomock.Controller
+	var region string = "east1"
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("single instance is existed", func() {
+		It("return the NodeAddress", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{*helper.NewTestInstance()}
+			nodeName := testInstances[0].InstanceID
+			expectedNodeAddress := []v1.NodeAddress{
+				{
+					Type:    v1.NodeExternalIP,
+					Address: testInstances[0].PublicIPAddress,
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: testInstances[0].PrivateIPAddress,
+				},
+			}
+
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceID(gomock.Any(), []string{nodeName}).
+				Return(testInstances, nil).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			nodeAddress, err := cloud.NodeAddresses(ctx, types.NodeName(nodeName))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(nodeAddress).Should(Equal(expectedNodeAddress))
+		})
+	})
+
+	Context("the instance is not existed", func() {
+		It("return error", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{}
+			nodeName := "testinstance"
+
+			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceID(gomock.Any(), []string{nodeName}).
+				Return(testInstances, notFoundErr).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			nodeAddress, err := cloud.NodeAddresses(ctx, types.NodeName(nodeName))
+			Expect(err).Should(HaveOccurred())
+			Expect(nodeAddress).Should(BeNil())
+		})
+	})
+
+	Context("some instances have same InstanceID are existed", func() {
+		It("return error", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{*helper.NewTestInstance(), *helper.NewTestInstance()}
+			nodeName := testInstances[0].InstanceID
+
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceID(gomock.Any(), []string{nodeName}).
+				Return(testInstances, nil).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			nodeAddress, err := cloud.NodeAddresses(ctx, types.NodeName(nodeName))
+			Expect(err).Should(HaveOccurred())
+			Expect(nodeAddress).Should(BeNil())
+		})
+	})
+})

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
@@ -357,3 +357,86 @@ var _ = Describe("InstanceType", func() {
 		})
 	})
 })
+
+var _ = Describe("InstanceTypeByProviderID", func() {
+	var ctrl *gomock.Controller
+	var region string = "east1"
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("single instance is existed", func() {
+		It("return the NodeAddress", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{*helper.NewTestInstance()}
+			testProviderID := "nifcloud:///east-11/i-abcd1234"
+			testInstanceUniqueID := "i-abcd1234"
+
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
+				Return(testInstances, nil).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			gotInstanceType, err := cloud.InstanceTypeByProviderID(ctx, testProviderID)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(gotInstanceType).Should(Equal(testInstances[0].InstanceType))
+		})
+	})
+
+	Context("the instance is not existed", func() {
+		It("return error", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{}
+			testProviderID := "nifcloud:///east-11/i-abcd1234"
+			testInstanceUniqueID := "i-abcd1234"
+
+			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
+				Return(testInstances, notFoundErr).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			nodeAddress, err := cloud.InstanceTypeByProviderID(ctx, testProviderID)
+			Expect(err).Should(HaveOccurred())
+			Expect(nodeAddress).Should(BeEmpty())
+		})
+	})
+
+	Context("some instances have same InstanceID are existed", func() {
+		It("return error", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{*helper.NewTestInstance(), *helper.NewTestInstance()}
+			testProviderID := "nifcloud:///east-11/i-abcd1234"
+			testInstanceUniqueID := "i-abcd1234"
+
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
+				Return(testInstances, nil).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			nodeAddress, err := cloud.InstanceTypeByProviderID(ctx, testProviderID)
+			Expect(err).Should(HaveOccurred())
+			Expect(nodeAddress).Should(BeEmpty())
+		})
+	})
+})

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
@@ -440,3 +440,86 @@ var _ = Describe("InstanceTypeByProviderID", func() {
 		})
 	})
 })
+
+var _ = Describe("InstanceExistsByProviderID", func() {
+	var ctrl *gomock.Controller
+	var region string = "east1"
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("single instance is existed", func() {
+		It("return true", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{*helper.NewTestInstance()}
+			testProviderID := "nifcloud:///east-11/i-abcd1234"
+			testInstanceUniqueID := "i-abcd1234"
+
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
+				Return(testInstances, nil).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			exist, err := cloud.InstanceExistsByProviderID(ctx, testProviderID)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(exist).Should(BeTrue())
+		})
+	})
+
+	Context("the instance is not existed", func() {
+		It("return false and error", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{}
+			testProviderID := "nifcloud:///east-11/i-abcd1234"
+			testInstanceUniqueID := "i-abcd1234"
+
+			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
+				Return(testInstances, notFoundErr).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			exist, err := cloud.InstanceExistsByProviderID(ctx, testProviderID)
+			Expect(err).Should(HaveOccurred())
+			Expect(exist).Should(BeFalse())
+		})
+	})
+
+	Context("some instances have same InstanceID are existed", func() {
+		It("return false and error", func() {
+			ctx := context.Background()
+			testInstances := []nifcloud.Instance{*helper.NewTestInstance(), *helper.NewTestInstance()}
+			testProviderID := "nifcloud:///east-11/i-abcd1234"
+			testInstanceUniqueID := "i-abcd1234"
+
+			c := nifcloud.NewMockCloudAPIClient(ctrl)
+			c.EXPECT().
+				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
+				Return(testInstances, nil).
+				Times(1)
+
+			cloud := &nifcloud.Cloud{}
+			cloud.SetClient(c)
+			cloud.SetRegion(region)
+
+			exist, err := cloud.InstanceExistsByProviderID(ctx, testProviderID)
+			Expect(err).Should(HaveOccurred())
+			Expect(exist).Should(BeFalse())
+		})
+	})
+})

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
@@ -996,3 +996,56 @@ var _ = Describe("getInstance", func() {
 		})
 	})
 })
+
+var _ = Describe("getNodeAddress", func() {
+	Context("given an instance has only public network", func() {
+		It("return the NodeAddress", func() {
+			testInstance := *helper.NewTestInstance()
+			testInstance.PrivateIPAddress = ""
+			expectedNodeAddress := []v1.NodeAddress{
+				{
+					Type:    v1.NodeExternalIP,
+					Address: testInstance.PublicIPAddress,
+				},
+			}
+
+			nodeAddress := nifcloud.ExportGetNodeAddress(testInstance)
+			Expect(nodeAddress).Should(Equal(expectedNodeAddress))
+		})
+	})
+
+	Context("given an instance has only private network", func() {
+		It("return the NodeAddress", func() {
+			testInstance := *helper.NewTestInstance()
+			testInstance.PublicIPAddress = ""
+			expectedNodeAddress := []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: testInstance.PrivateIPAddress,
+				},
+			}
+
+			nodeAddress := nifcloud.ExportGetNodeAddress(testInstance)
+			Expect(nodeAddress).Should(Equal(expectedNodeAddress))
+		})
+	})
+
+	Context("given an instance has both of public and private network", func() {
+		It("return the NodeAddress", func() {
+			testInstance := *helper.NewTestInstance()
+			expectedNodeAddress := []v1.NodeAddress{
+				{
+					Type:    v1.NodeExternalIP,
+					Address: testInstance.PublicIPAddress,
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: testInstance.PrivateIPAddress,
+				},
+			}
+
+			nodeAddress := nifcloud.ExportGetNodeAddress(testInstance)
+			Expect(nodeAddress).Should(Equal(expectedNodeAddress))
+		})
+	})
+})

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_instances_test.go
@@ -65,7 +65,7 @@ var _ = Describe("NodeAddresses", func() {
 			testInstances := []nifcloud.Instance{}
 			nodeName := "testinstance"
 
-			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			notFoundErr := cloudprovider.InstanceNotFound
 			c := nifcloud.NewMockCloudAPIClient(ctrl)
 			c.EXPECT().
 				DescribeInstancesByInstanceID(gomock.Any(), []string{nodeName}).
@@ -157,7 +157,7 @@ var _ = Describe("NodeAddressesByProviderID", func() {
 			testProviderID := "nifcloud:///east-11/i-abcd1234"
 			testInstanceUniqueID := "i-abcd1234"
 
-			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			notFoundErr := cloudprovider.InstanceNotFound
 			c := nifcloud.NewMockCloudAPIClient(ctrl)
 			c.EXPECT().
 				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
@@ -239,7 +239,7 @@ var _ = Describe("InstanceID", func() {
 			testInstances := []nifcloud.Instance{}
 			nodeName := "testinstance"
 
-			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			notFoundErr := cloudprovider.InstanceNotFound
 			c := nifcloud.NewMockCloudAPIClient(ctrl)
 			c.EXPECT().
 				DescribeInstancesByInstanceID(gomock.Any(), []string{nodeName}).
@@ -319,7 +319,7 @@ var _ = Describe("InstanceType", func() {
 			testInstances := []nifcloud.Instance{}
 			nodeName := "testinstance"
 
-			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			notFoundErr := cloudprovider.InstanceNotFound
 			c := nifcloud.NewMockCloudAPIClient(ctrl)
 			c.EXPECT().
 				DescribeInstancesByInstanceID(gomock.Any(), []string{nodeName}).
@@ -401,7 +401,7 @@ var _ = Describe("InstanceTypeByProviderID", func() {
 			testProviderID := "nifcloud:///east-11/i-abcd1234"
 			testInstanceUniqueID := "i-abcd1234"
 
-			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			notFoundErr := cloudprovider.InstanceNotFound
 			c := nifcloud.NewMockCloudAPIClient(ctrl)
 			c.EXPECT().
 				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
@@ -484,7 +484,7 @@ var _ = Describe("InstanceExistsByProviderID", func() {
 			testProviderID := "nifcloud:///east-11/i-abcd1234"
 			testInstanceUniqueID := "i-abcd1234"
 
-			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			notFoundErr := cloudprovider.InstanceNotFound
 			c := nifcloud.NewMockCloudAPIClient(ctrl)
 			c.EXPECT().
 				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
@@ -577,7 +577,7 @@ var _ = Describe("InstanceExists", func() {
 				},
 			}
 
-			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			notFoundErr := cloudprovider.InstanceNotFound
 			c := nifcloud.NewMockCloudAPIClient(ctrl)
 			c.EXPECT().
 				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
@@ -736,7 +736,7 @@ var _ = Describe("InstanceShutdown", func() {
 				},
 			}
 
-			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			notFoundErr := cloudprovider.InstanceNotFound
 			c := nifcloud.NewMockCloudAPIClient(ctrl)
 			c.EXPECT().
 				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
@@ -851,7 +851,7 @@ var _ = Describe("InstanceMetadata", func() {
 				},
 			}
 
-			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			notFoundErr := cloudprovider.InstanceNotFound
 			c := nifcloud.NewMockCloudAPIClient(ctrl)
 			c.EXPECT().
 				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).
@@ -951,7 +951,7 @@ var _ = Describe("getInstance", func() {
 				},
 			}
 
-			notFoundErr := helper.NewMockAPIError(nifcloud.ExportErrorCodeInstanceNotFound)
+			notFoundErr := cloudprovider.InstanceNotFound
 			c := nifcloud.NewMockCloudAPIClient(ctrl)
 			c.EXPECT().
 				DescribeInstancesByInstanceUniqueID(gomock.Any(), []string{testInstanceUniqueID}).


### PR DESCRIPTION
## Summary

- Add test for methods of nifcloud_instances.go.
- Fix to use isAPIError for handling error of computing API
  - 529c42776d3410c588f06cdac794e54e74b3f49d

## Review

- [ ] CI is successful.
