### PR TITLE
Feature/add release helm ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,16 @@
 name: Release
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - 'v*'
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  release:
+  release-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,3 +40,36 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  release-helm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Helm Package
+        run: make helm-package
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_GENERATE_RELEASE_NOTES: true
+          CR_RELEASE_NAME_TEMPLATE: 'v{{ .Version }}'
+        with:
+          skip_packaging: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries for programs and plugins
 /bin
+/.cr-release-packages
 *.exe
 *.exe~
 *.dll

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 PKG:=github.com/nifcloud/nifcloud-cloud-controller-manager
 IMAGE:=ghcr.io/nifcloud/nifcloud-cloud-controller-manager
 VERSION:=$(shell git describe --tags --dirty --match="v*")
+CHART_VERSION=${VERSION:v%=%}
 LDFLAGS:="-X k8s.io/component-base/version.gitVersion=$(VERSION) -s -w"
 
 build:
@@ -22,4 +23,4 @@ push:
 	docker push $(IMAGE):$(VERSION)
 
 helm-package:
-	cd charts; helm package nifcloud-cloud-controller-manager
+	cd charts; helm package nifcloud-cloud-controller-manager -d ../.cr-release-packages --version=${CHART_VERSION} --app-version=${VERSION}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
    ```
 2. Add helm repository.
    ```sh
-   helm repo add nifcloud-cloud-controller-manager https://raw.githubusercontent.com/nifcloud/nifcloud-cloud-controller-manager/main/charts
+   helm repo add nifcloud-cloud-controller-manager https://nifcloud.github.io/nifcloud-cloud-controller-manager
    helm repo update
    ```
 3. Install. (Please change the parameter `<REGION>` to your environment.)

--- a/charts/nifcloud-cloud-controller-manager/Chart.yaml
+++ b/charts/nifcloud-cloud-controller-manager/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.1.0"
+appVersion: "v0.1.0"


### PR DESCRIPTION
## Summary

- Add Github Action [Helm Chart Releaser](https://github.com/marketplace/actions/helm-chart-releaser) to release helm.
  - Helm Chart Releaser creates release, so I changed release CI is triggered from tag.
  - The chart and app version is defined from tag that have `v` prefix. 

## Review

- [x] CI is successful.
  -  https://github.com/nifcloud/nifcloud-cloud-controller-manager/actions/runs/9478722539
- [x] release is created as expected.
  - https://github.com/nifcloud/nifcloud-cloud-controller-manager/releases/tag/v1.2.0

## Test

``` bash
docker run -it --rm --entrypoint=ash alpine/helm:latest
/apps # helm repo add nifcloud-cloud-controller-manager https://nifcloud.github.io/nifcloud-cloud-controller-manager
"nifcloud-cloud-controller-manager" has been added to your repositories
/apps # helm repo update
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "nifcloud-cloud-controller-manager" chart repository
Update Complete. ⎈Happy Helming!⎈
/apps # helm search repo nifcloud-cloud-controller-manager
NAME                                                    CHART VERSION   APP VERSION     DESCRIPTION                                       
nifcloud-cloud-controller-manager/nifcloud-clou...      1.2.0           v1.2.0          A Helm chart for NIFCLOUD cloud controller manager
/apps # helm show chart nifcloud-cloud-controller-manager/nifcloud-cloud-controller-manager
apiVersion: v2
appVersion: v1.2.0
description: A Helm chart for NIFCLOUD cloud controller manager
name: nifcloud-cloud-controller-manager
type: application
version: 1.2.0
```
