### PR TITLE
Add nifcloud client test related to elb Part2

### DIFF
--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_client.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_client.go
@@ -843,6 +843,7 @@ func (c *nifcloudAPIClient) DeregisterInstancesFromElasticLoadBalancer(ctx conte
 		ElasticLoadBalancerName: nifcloud.String(elasticLoadBalancer.Name),
 		ElasticLoadBalancerPort: nifcloud.Int32(elasticLoadBalancer.LoadBalancerPort),
 		InstancePort:            nifcloud.Int32(elasticLoadBalancer.InstancePort),
+		Protocol:                types.ProtocolOfNiftyDeregisterInstancesFromElasticLoadBalancerRequest(elasticLoadBalancer.Protocol),
 		Instances: &types.ListOfRequestInstancesOfNiftyDeregisterInstancesFromElasticLoadBalancer{
 			Member: deregisterInstances,
 		},

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_client_test.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_client_test.go
@@ -1192,4 +1192,97 @@ var _ = Describe("nifcloudAPIClient", func() {
 			})
 		})
 	})
+
+	var _ = Describe("DeregisterInstancesFromElasticLoadBalancer", func() {
+		Describe("deregistering instances is success", func() {
+			testLoadBalancerName := "testelb"
+
+			BeforeEach(func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					lo.Must0(r.ParseForm())
+					Expect(r.Form.Get("ElasticLoadBalancerName")).Should(Equal(testLoadBalancerName))
+					Expect(r.Form.Get("Instances.member.1.InstanceId")).Should(Equal("testinstance"))
+					_, _ = w.Write(lo.Must(os.ReadFile("./testdata/deregister_instances_from_elastic_load_balancer.xml")))
+				})
+			})
+
+			It("return nil", func() {
+				ctx := context.Background()
+				testElasticLoadBalancers := helper.NewTestElasticLoadBalancer(testLoadBalancerName)
+				testInstances := []nifcloud.Instance{*helper.NewTestInstance()}
+				testInstances[0].InstanceID = "testinstance"
+				gotErr := testNifcloudAPIClient.DeregisterInstancesFromElasticLoadBalancer(ctx, &testElasticLoadBalancers[0], testInstances)
+				Expect(gotErr).ShouldNot(HaveOccurred())
+			})
+		})
+
+		Describe("the specified elastic load balancer is not existed", func() {
+			testLoadBalancerName := "testelb"
+
+			BeforeEach(func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					lo.Must0(r.ParseForm())
+					Expect(r.Form.Get("ElasticLoadBalancerName")).Should(Equal(testLoadBalancerName))
+					Expect(r.Form.Get("Instances.member.1.InstanceId")).Should(Equal("testinstance"))
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write(lo.Must(os.ReadFile("./testdata/deregister_instances_from_elastic_load_balancer_not_found_load_balancer.xml")))
+				})
+			})
+
+			It("return error", func() {
+				ctx := context.Background()
+				testElasticLoadBalancers := helper.NewTestElasticLoadBalancer(testLoadBalancerName)
+				testInstances := []nifcloud.Instance{*helper.NewTestInstance()}
+				testInstances[0].InstanceID = "testinstance"
+				gotErr := testNifcloudAPIClient.RegisterInstancesWithElasticLoadBalancer(ctx, &testElasticLoadBalancers[0], testInstances)
+				Expect(gotErr).Should(HaveOccurred())
+			})
+		})
+
+		Describe("the specified elastic load balancer does not have the port", func() {
+			testLoadBalancerName := "testelb"
+
+			BeforeEach(func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					lo.Must0(r.ParseForm())
+					Expect(r.Form.Get("ElasticLoadBalancerName")).Should(Equal(testLoadBalancerName))
+					Expect(r.Form.Get("Instances.member.1.InstanceId")).Should(Equal("testinstance"))
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write(lo.Must(os.ReadFile("./testdata/deregister_instances_from_elastic_load_balancer_not_found_port.xml")))
+				})
+			})
+
+			It("return error", func() {
+				ctx := context.Background()
+				testElasticLoadBalancers := helper.NewTestElasticLoadBalancer(testLoadBalancerName)
+				testInstances := []nifcloud.Instance{*helper.NewTestInstance()}
+				testInstances[0].InstanceID = "testinstance"
+				gotErr := testNifcloudAPIClient.DeregisterInstancesFromElasticLoadBalancer(ctx, &testElasticLoadBalancers[0], testInstances)
+				Expect(gotErr).Should(HaveOccurred())
+			})
+		})
+
+		Describe("the specified instance is not existed", func() {
+			testLoadBalancerName := "testelb"
+
+			BeforeEach(func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					lo.Must0(r.ParseForm())
+					Expect(r.Form.Get("ElasticLoadBalancerName")).Should(Equal(testLoadBalancerName))
+					Expect(r.Form.Get("Instances.member.1.InstanceId")).Should(Equal("testinstance"))
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write(lo.Must(os.ReadFile("./testdata/deregister_instances_from_elastic_load_balancer_not_found_instances.xml")))
+				})
+			})
+
+			It("return error", func() {
+				ctx := context.Background()
+				testElasticLoadBalancers := helper.NewTestElasticLoadBalancer(testLoadBalancerName)
+				testInstances := []nifcloud.Instance{*helper.NewTestInstance()}
+				testInstances[0].InstanceID = "testinstance"
+				gotErr := testNifcloudAPIClient.DeregisterInstancesFromElasticLoadBalancer(ctx, &testElasticLoadBalancers[0], testInstances)
+				Expect(gotErr).Should(HaveOccurred())
+			})
+		})
+	})
 })

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_client_test.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_client_test.go
@@ -1029,4 +1029,51 @@ var _ = Describe("nifcloudAPIClient", func() {
 			})
 		})
 	})
+
+	var _ = Describe("DeleteElasticLoadBalancer", func() {
+		Describe("deleting elastic load balancer is success", func() {
+			testLoadBalancerName := "testelb"
+
+			BeforeEach(func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					lo.Must0(r.ParseForm())
+					Expect(r.Form.Get("ElasticLoadBalancerName")).Should(Equal(testLoadBalancerName))
+					Expect(r.Form.Get("ElasticLoadBalancerPort")).Should(Equal("80"))
+					Expect(r.Form.Get("InstancePort")).Should(Equal("30000"))
+					Expect(r.Form.Get("Protocol")).Should(Equal("TCP"))
+					_, _ = w.Write(lo.Must(os.ReadFile("./testdata/delete_elastic_load_balancer.xml")))
+				})
+			})
+
+			It("return nil", func() {
+				ctx := context.Background()
+				testElasticLoadBalancers := helper.NewTestElasticLoadBalancer(testLoadBalancerName)
+				gotErr := testNifcloudAPIClient.DeleteElasticLoadBalancer(ctx, &testElasticLoadBalancers[0])
+				Expect(gotErr).ShouldNot(HaveOccurred())
+			})
+		})
+
+		Describe("the specified elastic load balancer is not existed", func() {
+			testLoadBalancerName := "testelb"
+
+			BeforeEach(func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					lo.Must0(r.ParseForm())
+					Expect(r.Form.Get("ElasticLoadBalancerName")).Should(Equal(testLoadBalancerName))
+					Expect(r.Form.Get("ElasticLoadBalancerPort")).Should(Equal("80"))
+					Expect(r.Form.Get("InstancePort")).Should(Equal("30000"))
+					Expect(r.Form.Get("Protocol")).Should(Equal("TCP"))
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write(lo.Must(os.ReadFile("./testdata/delete_elastic_load_balancer_not_found_load_balancer.xml")))
+				})
+			})
+
+			It("return error", func() {
+				ctx := context.Background()
+				testElasticLoadBalancers := helper.NewTestElasticLoadBalancer(testLoadBalancerName)
+				gotErr := testNifcloudAPIClient.DeleteElasticLoadBalancer(ctx, &testElasticLoadBalancers[0])
+				Expect(gotErr).Should(HaveOccurred())
+			})
+		})
+	})
 })

--- a/pkg/cloudprovider/providers/nifcloud/nifcloud_client_test.go
+++ b/pkg/cloudprovider/providers/nifcloud/nifcloud_client_test.go
@@ -1076,4 +1076,120 @@ var _ = Describe("nifcloudAPIClient", func() {
 			})
 		})
 	})
+
+	var _ = Describe("RegisterInstancesWithElasticLoadBalancer", func() {
+		Describe("registering instances is success", func() {
+			testLoadBalancerName := "testelb"
+
+			BeforeEach(func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					lo.Must0(r.ParseForm())
+					Expect(r.Form.Get("ElasticLoadBalancerName")).Should(Equal(testLoadBalancerName))
+					Expect(r.Form.Get("Instances.member.1.InstanceId")).Should(Equal("testinstance"))
+					_, _ = w.Write(lo.Must(os.ReadFile("./testdata/register_instances_with_elastic_load_balancer.xml")))
+				})
+			})
+
+			It("return nil", func() {
+				ctx := context.Background()
+				testElasticLoadBalancers := helper.NewTestElasticLoadBalancer(testLoadBalancerName)
+				testInstances := []nifcloud.Instance{*helper.NewTestInstance()}
+				testInstances[0].InstanceID = "testinstance"
+				gotErr := testNifcloudAPIClient.RegisterInstancesWithElasticLoadBalancer(ctx, &testElasticLoadBalancers[0], testInstances)
+				Expect(gotErr).ShouldNot(HaveOccurred())
+			})
+		})
+
+		Describe("the specified elastic load balancer is not existed", func() {
+			testLoadBalancerName := "testelb"
+
+			BeforeEach(func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					lo.Must0(r.ParseForm())
+					Expect(r.Form.Get("ElasticLoadBalancerName")).Should(Equal(testLoadBalancerName))
+					Expect(r.Form.Get("Instances.member.1.InstanceId")).Should(Equal("testinstance"))
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write(lo.Must(os.ReadFile("./testdata/register_instances_with_elastic_load_balancer_not_found_load_balancer.xml")))
+				})
+			})
+
+			It("return error", func() {
+				ctx := context.Background()
+				testElasticLoadBalancers := helper.NewTestElasticLoadBalancer(testLoadBalancerName)
+				testInstances := []nifcloud.Instance{*helper.NewTestInstance()}
+				testInstances[0].InstanceID = "testinstance"
+				gotErr := testNifcloudAPIClient.RegisterInstancesWithElasticLoadBalancer(ctx, &testElasticLoadBalancers[0], testInstances)
+				Expect(gotErr).Should(HaveOccurred())
+			})
+		})
+
+		Describe("the specified elastic load balancer does not have the port", func() {
+			testLoadBalancerName := "testelb"
+
+			BeforeEach(func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					lo.Must0(r.ParseForm())
+					Expect(r.Form.Get("ElasticLoadBalancerName")).Should(Equal(testLoadBalancerName))
+					Expect(r.Form.Get("Instances.member.1.InstanceId")).Should(Equal("testinstance"))
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write(lo.Must(os.ReadFile("./testdata/register_instances_with_elastic_load_balancer_not_found_port.xml")))
+				})
+			})
+
+			It("return error", func() {
+				ctx := context.Background()
+				testElasticLoadBalancers := helper.NewTestElasticLoadBalancer(testLoadBalancerName)
+				testInstances := []nifcloud.Instance{*helper.NewTestInstance()}
+				testInstances[0].InstanceID = "testinstance"
+				gotErr := testNifcloudAPIClient.RegisterInstancesWithElasticLoadBalancer(ctx, &testElasticLoadBalancers[0], testInstances)
+				Expect(gotErr).Should(HaveOccurred())
+			})
+		})
+
+		Describe("the specified instance is not existed", func() {
+			testLoadBalancerName := "testelb"
+
+			BeforeEach(func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					lo.Must0(r.ParseForm())
+					Expect(r.Form.Get("ElasticLoadBalancerName")).Should(Equal(testLoadBalancerName))
+					Expect(r.Form.Get("Instances.member.1.InstanceId")).Should(Equal("testinstance"))
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write(lo.Must(os.ReadFile("./testdata/register_instances_with_elastic_load_balancer_not_found_instances.xml")))
+				})
+			})
+
+			It("return error", func() {
+				ctx := context.Background()
+				testElasticLoadBalancers := helper.NewTestElasticLoadBalancer(testLoadBalancerName)
+				testInstances := []nifcloud.Instance{*helper.NewTestInstance()}
+				testInstances[0].InstanceID = "testinstance"
+				gotErr := testNifcloudAPIClient.RegisterInstancesWithElasticLoadBalancer(ctx, &testElasticLoadBalancers[0], testInstances)
+				Expect(gotErr).Should(HaveOccurred())
+			})
+		})
+
+		Describe("the specified instance is already registered", func() {
+			testLoadBalancerName := "testelb"
+
+			BeforeEach(func() {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					lo.Must0(r.ParseForm())
+					Expect(r.Form.Get("ElasticLoadBalancerName")).Should(Equal(testLoadBalancerName))
+					Expect(r.Form.Get("Instances.member.1.InstanceId")).Should(Equal("testinstance"))
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write(lo.Must(os.ReadFile("./testdata/register_instances_with_elastic_load_balancer_duplicate.xml")))
+				})
+			})
+
+			It("return error", func() {
+				ctx := context.Background()
+				testElasticLoadBalancers := helper.NewTestElasticLoadBalancer(testLoadBalancerName)
+				testInstances := []nifcloud.Instance{*helper.NewTestInstance()}
+				testInstances[0].InstanceID = "testinstance"
+				gotErr := testNifcloudAPIClient.RegisterInstancesWithElasticLoadBalancer(ctx, &testElasticLoadBalancers[0], testInstances)
+				Expect(gotErr).Should(HaveOccurred())
+			})
+		})
+	})
 })

--- a/pkg/cloudprovider/providers/nifcloud/testdata/delete_elastic_load_balancer.xml
+++ b/pkg/cloudprovider/providers/nifcloud/testdata/delete_elastic_load_balancer.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><NiftyDeleteElasticLoadBalancerResponse xmlns="https://computing.api.nifcloud.com/api/"><NiftyDeleteElasticLoadBalancerResult/><ResponseMetadata><RequestId>59aaf26f-43cd-4c9c-a9cc-d148a7fac1ca</RequestId></ResponseMetadata></NiftyDeleteElasticLoadBalancerResponse>

--- a/pkg/cloudprovider/providers/nifcloud/testdata/delete_elastic_load_balancer_not_found_load_balancer.xml
+++ b/pkg/cloudprovider/providers/nifcloud/testdata/delete_elastic_load_balancer_not_found_load_balancer.xml
@@ -1,0 +1,1 @@
+<Response><Errors><Error><Code>Client.InvalidParameterNotFound.ElasticLoadBalancer</Code><Message>The ElasticLoadBalancerName 'testelb' does not exist.</Message></Error></Errors><RequestID>16534e15-2ad6-4b7f-a757-7ea82649514a</RequestID></Response>

--- a/pkg/cloudprovider/providers/nifcloud/testdata/deregister_instances_from_elastic_load_balancer.xml
+++ b/pkg/cloudprovider/providers/nifcloud/testdata/deregister_instances_from_elastic_load_balancer.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><NiftyDeregisterInstancesFromElasticLoadBalancerResponse xmlns="https://computing.api.nifcloud.com/api/"><NiftyDeregisterInstancesFromElasticLoadBalancerResult/><ResponseMetadata><RequestId>73fa08a7-87d5-450e-a59b-05243d10e78b</RequestId></ResponseMetadata></NiftyDeregisterInstancesFromElasticLoadBalancerResponse>

--- a/pkg/cloudprovider/providers/nifcloud/testdata/deregister_instances_from_elastic_load_balancer_not_found_instances.xml
+++ b/pkg/cloudprovider/providers/nifcloud/testdata/deregister_instances_from_elastic_load_balancer_not_found_instances.xml
@@ -1,0 +1,1 @@
+<Response><Errors><Error><Code>Client.InvalidParameterNotFound.Instance</Code><Message>The Instances_member_InstanceId 'testinstance' does not register at the ElasticLoadBalancer 'testelb'.</Message></Error></Errors><RequestID>72abc6be-53e0-4dd0-ae3a-998dd5b34ac1</RequestID></Response>

--- a/pkg/cloudprovider/providers/nifcloud/testdata/deregister_instances_from_elastic_load_balancer_not_found_load_balancer.xml
+++ b/pkg/cloudprovider/providers/nifcloud/testdata/deregister_instances_from_elastic_load_balancer_not_found_load_balancer.xml
@@ -1,0 +1,1 @@
+<Response><Errors><Error><Code>Client.InvalidParameterNotFound.ElasticLoadBalancer</Code><Message>The ElasticLoadBalancerName 'testelb' does not exist.</Message></Error></Errors><RequestID>73acef14-8b85-4067-8695-adf8ebceed84</RequestID></Response>

--- a/pkg/cloudprovider/providers/nifcloud/testdata/deregister_instances_from_elastic_load_balancer_not_found_port.xml
+++ b/pkg/cloudprovider/providers/nifcloud/testdata/deregister_instances_from_elastic_load_balancer_not_found_port.xml
@@ -1,0 +1,1 @@
+<Response><Errors><Error><Code>Client.InvalidParameterNotFound.Protocol.or.ElasticLoadBalancerPort</Code><Message>The requested ElasticLoadBalancerName ('testelb') does not have this protocol and port (Protocol: 'TCP',ElasticLoadBalancerPort: '80',InstancePort: '30000').</Message></Error></Errors><RequestID>69773dcf-230f-493b-b10e-adf464d57e40</RequestID></Response>

--- a/pkg/cloudprovider/providers/nifcloud/testdata/register_instances_with_elastic_load_balancer.xml
+++ b/pkg/cloudprovider/providers/nifcloud/testdata/register_instances_with_elastic_load_balancer.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><NiftyRegisterInstancesWithElasticLoadBalancerResponse xmlns="https://computing.api.nifcloud.com/api/"><NiftyRegisterInstancesWithElasticLoadBalancerResult/><ResponseMetadata><RequestId>f64b0868-f5b1-4498-a7bf-4864c79d6f8d</RequestId></ResponseMetadata></NiftyRegisterInstancesWithElasticLoadBalancerResponse>

--- a/pkg/cloudprovider/providers/nifcloud/testdata/register_instances_with_elastic_load_balancer_duplicate.xml
+++ b/pkg/cloudprovider/providers/nifcloud/testdata/register_instances_with_elastic_load_balancer_duplicate.xml
@@ -1,0 +1,1 @@
+<Response><Errors><Error><Code>Client.Inoperable.ElasticLoadBalancer.HavingRegisteredInstance</Code><Message>The Instances_member_InstanceId 'testinstance' already exists with this ElasticLoadBalancer.</Message></Error></Errors><RequestID>4c0a1c3a-5856-4fe1-ab4b-8d8f1653fceb</RequestID></Response>

--- a/pkg/cloudprovider/providers/nifcloud/testdata/register_instances_with_elastic_load_balancer_not_found_instances.xml
+++ b/pkg/cloudprovider/providers/nifcloud/testdata/register_instances_with_elastic_load_balancer_not_found_instances.xml
@@ -1,0 +1,1 @@
+<Response><Errors><Error><Code>Client.InvalidParameterNotFound.Instance</Code><Message>The Instances_member_InstanceId 'testinstance' does not exist.</Message></Error></Errors><RequestID>1325e2f6-19e5-458e-bd39-0732fa92c85c</RequestID></Response>

--- a/pkg/cloudprovider/providers/nifcloud/testdata/register_instances_with_elastic_load_balancer_not_found_load_balancer.xml
+++ b/pkg/cloudprovider/providers/nifcloud/testdata/register_instances_with_elastic_load_balancer_not_found_load_balancer.xml
@@ -1,0 +1,1 @@
+<Response><Errors><Error><Code>Client.InvalidParameterNotFound.ElasticLoadBalancer</Code><Message>The ElasticLoadBalancerName 'testelb' does not exist.</Message></Error></Errors><RequestID>261a94c9-5a9e-4eef-baac-a453ab52146e</RequestID></Response>

--- a/pkg/cloudprovider/providers/nifcloud/testdata/register_instances_with_elastic_load_balancer_not_found_port.xml
+++ b/pkg/cloudprovider/providers/nifcloud/testdata/register_instances_with_elastic_load_balancer_not_found_port.xml
@@ -1,0 +1,1 @@
+<Response><Errors><Error><Code>Client.InvalidParameterNotFound.Protocol.or.ElasticLoadBalancerPort</Code><Message>The requested ElasticLoadBalancerName ('testelb') does not have this protocol and port (Protocol: 'TCP',ElasticLoadBalancerPort: '80',InstancePort: '30000').</Message></Error></Errors><RequestID>0283a0cb-990d-4850-9aaa-f0b99101d789</RequestID></Response>


### PR DESCRIPTION
## Summary

- Add tests to the methods related to elb in nifcloud_client.go.
  - `DeleteElasticLoadBalancer`
  - `RegisterInstancesWithElasticLoadBalancer`
  - `DeregisterInstancesFromElasticLoadBalancer`

## Review

- [ ] CI is successful.